### PR TITLE
Deprecation leading into v0.8

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,5 +5,5 @@ CurrentModule = ParallelUtilities
 # ParallelUtilities.jl
 
 ```@autodocs
-Modules = [ParallelUtilities]
+Modules = [ParallelUtilities, ParallelUtilities.ClusterQueryUtils]
 ```

--- a/src/ParallelUtilities.jl
+++ b/src/ParallelUtilities.jl
@@ -1,31 +1,32 @@
 module ParallelUtilities
 using ProgressMeter
-using DataStructures
 using Reexport
 using OffsetArrays
+
 @reexport using Distributed
 
-export  ProductSplit,
-	ntasks,
-	whichproc,
-	procrange_recast,
-	localindex,
-	whichproc_localindex,
-	extremadims,
-	extrema_commonlastdim,
-	nodenames,
-	gethostnames,
-	nprocs_node,
-	pmapbatch,
-	pmapbatch_elementwise,
-	pmapsum,
-	pmapsum_elementwise,
-	pmapreduce,
-	pmapreduce_commutative,
-	pmapreduce_commutative_elementwise
+export ProductSplit,
+    ntasks,
+    whichproc,
+    procrange_recast,
+    localindex,
+    whichproc_localindex,
+    extremadims,
+    extrema_commonlastdim,
+    pmapbatch,
+    pmapbatch_elementwise,
+    pmapsum,
+    pmapsum_elementwise,
+    pmapreduce,
+    pmapreduce_commutative,
+    pmapreduce_commutative_elementwise
 
 include("errors.jl")
 include("productsplit.jl")
+
+include("clusterquery.jl")
+@reexport using .ClusterQueryUtils
+
 include("utils.jl")
 include("trees.jl")
 include("mapreduce.jl")

--- a/src/clusterquery.jl
+++ b/src/clusterquery.jl
@@ -1,0 +1,105 @@
+module ClusterQueryUtils
+
+using Distributed
+using DataStructures
+
+@deprecate gethostnames hostnames
+export hostnames
+export nodenames
+export procs_node
+export nprocs_node
+
+"""
+    gethostnames(procs = workers())
+
+Return the hostname of each worker in `procs`. This is obtained by evaluating 
+`Libc.gethostname()` on each worker asynchronously.
+
+!!! warn
+    `gethostnames` is deprecated in favor of `hostnames`    
+"""
+gethostnames
+
+"""
+    hostnames(procs = workers())
+
+Return the hostname of each worker in `procs`. This is obtained by evaluating 
+`Libc.gethostname()` on each worker asynchronously.
+"""
+function hostnames(procs = workers())
+    Base.depwarn("hostnames will not be exported in a future release. "*
+    "It may be imported from the module ClusterQueryUtils", :hostnames)
+
+    hostnames = Vector{String}(undef, length(procs))
+
+    @sync for (ind,p) in enumerate(procs)
+        @async hostnames[ind] = @fetchfrom p Libc.gethostname()
+    end
+    return hostnames
+end
+
+
+"""
+    nodenames(procs = workers())
+
+Return the unique hostnames that the workers in `procs` lie on. 
+On an HPC system these are usually the hostnames of the nodes involved.
+"""
+nodenames(procs = workers()) = nodenames(hostnames(procs))
+
+function nodenames(hostnames::AbstractVector{String})
+   Base.depwarn("nodenames will not be exported in a future release. "*
+    "It may be imported from the module ClusterQueryUtils", :nodenames)
+    
+    unique(hostnames)
+end
+
+"""
+    procs_node(procs = workers())
+
+Return the worker ids on each host of the cluster.
+On an HPC system this would return the workers on each node.
+"""
+function procs_node(procs = workers())
+    hosts = hostnames(procs)
+    nodes = nodenames(hosts)
+    procs_node(procs, hosts, nodes)
+end
+
+function procs_node(procs, hosts, nodes)
+    Base.depwarn("procs_node will not be exported in a future release. "*
+        "It may be imported from the module ClusterQueryUtils", :procs_node)
+    
+    OrderedDict(node => procs[findall(isequal(node),hosts)] for node in nodes)
+end
+
+"""
+    nprocs_node(procs = workers())
+
+Return the number of workers on each host.
+On an HPC system this would return the number of workers on each node.
+"""
+function nprocs_node(procs = workers())
+    nprocs_node(hostnames(procs))
+end
+
+function nprocs_node(hostnames::AbstractVector{String})
+    nodes = nodenames(hostnames)
+    nprocs_node(hostnames, nodes)
+end
+
+function nprocs_node(hostnames::AbstractVector, nodes::AbstractVector)
+    Base.depwarn("nprocs_node will not be exported in a future release. "*
+        "It may be imported from the module ClusterQueryUtils", :nprocs_node)
+
+    OrderedDict(node => count(isequal(node), hostnames) for node in nodes)
+end
+
+function nprocs_node(d::AbstractDict)
+    Base.depwarn("nprocs_node will not be exported in a future release. "*
+        "It may be imported from the module ClusterQueryUtils", :nprocs_node)
+
+    OrderedDict(node => length(procs) for (node, procs) in d)
+end
+
+end

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -220,8 +220,17 @@ end
 
 function pmapreduceworkers(fmap::Function, freduce::Function, iterators::Tuple,
     tree, branches, ord::Ordering, args...;
-    showprogress::Bool = false, progressdesc = "Progress in pmapreduce : ",
     kwargs...)
+
+    kwargs_ = Dict(kwargs)
+    if haskey(kwargs, :showprogress)
+        Base.depwarn("showprogress is deprecated and will be removed in a future release", :pmapreduceworkers)
+    end
+
+    showprogress = get(kwargs, :showprogress, false)
+    progressdesc = get(kwargs, :progressdesc, "Progress in pmapreduce : ")
+    delete!(kwargs_, :showprogress)
+    delete!(kwargs_, :progressdesc)
 
     num_workers_active = nworkersactive(iterators)
     Nmaptotal = num_workers_active
@@ -244,7 +253,7 @@ function pmapreduceworkers(fmap::Function, freduce::Function, iterators::Tuple,
 
                 @spawnat p mapTreeNode(fmap, iterable_on_proc, rank, mypipe,
                     showprogress ? progresschannel : nothing,
-                    args...;kwargs...)
+                    args...; kwargs_...)
 
                 @spawnat p reduceTreeNode(freduce, SubTreeNode(rank),
                     mypipe, ord, showprogress ? progresschannel : nothing)

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -1,7 +1,7 @@
-# Store the rank with the value, necessary for collecting values in order`
+# Store the rank with the value, necessary for collecting values in order
 struct pval{T}
-	rank :: Int
-	value :: T
+    rank :: Int
+    value :: T
 end
 
 # Function to obtain the value of pval types
@@ -18,39 +18,39 @@ Base.:(==)(p1::pval,p2::pval) = (p1.rank == p2.rank) && (value(p1) == value(p2))
 
 # Wrap a pval around the mapped value if sorting is necessary
 function maybepvalput!(pipe::BranchChannel{T}, rank, val) where {T}
-	put!(pipe.selfchannels.out,val)
+    put!(pipe.selfchannels.out,val)
 end
 function maybepvalput!(pipe::BranchChannel{T}, rank, val) where {T<:pval}
-	valT = T(rank,value(val))
-	put!(pipe.selfchannels.out, valT)
+    valT = T(rank,value(val))
+    put!(pipe.selfchannels.out, valT)
 end
 
 function indicatemapprogress!(::Nothing, rank) end
 function indicatemapprogress!(progress::RemoteChannel, rank)
-	put!(progress, (true,false,rank))
+    put!(progress, (true,false,rank))
 end
 
 function indicatefailure!(::Nothing, rank) end
 function indicatefailure!(progress::RemoteChannel, rank)
-	put!(progress, (false,false,rank))
+    put!(progress, (false,false,rank))
 end
 
 function mapTreeNode(fmap::Function, iterator, rank, pipe::BranchChannel,
-	progress::Union{Nothing,RemoteChannel}, args...;kwargs...)
-	# Evaluate the function
-	# Store the error flag locally
-	# If there are no errors then store the result locally
-	# No communication with other nodes happens here other than indicating the progress status
-	try
-		res = fmap(iterator, args...;kwargs...)
-		maybepvalput!(pipe, rank, res)
-		put!(pipe.selfchannels.err, false)
-		indicatemapprogress!(progress, rank)
-	catch
-		put!(pipe.selfchannels.err, true)
-		indicatefailure!(progress, rank)
-		rethrow()
-	end
+    progress::Union{Nothing,RemoteChannel}, args...;kwargs...)
+    # Evaluate the function
+    # Store the error flag locally
+    # If there are no errors then store the result locally
+    # No communication with other nodes happens here other than indicating the progress status
+    try
+        res = fmap(iterator, args...;kwargs...)
+        maybepvalput!(pipe, rank, res)
+        put!(pipe.selfchannels.err, false)
+        indicatemapprogress!(progress, rank)
+    catch
+        put!(pipe.selfchannels.err, true)
+        indicatefailure!(progress, rank)
+        rethrow()
+    end
 end
 
 ############################################################################################
@@ -63,234 +63,234 @@ struct Unsorted <: Ordering end
 
 abstract type ReductionNode end
 struct TopTreeNode <: ReductionNode
-	rank :: Int
+    rank :: Int
 end
 struct SubTreeNode <: ReductionNode
-	rank :: Int
+    rank :: Int
 end
 
 function reducedvalue(freduce::Function, rank,
-	pipe::BranchChannel, ifsorted::Ordering)
+    pipe::BranchChannel, ifsorted::Ordering)
 
-	reducedvalue(freduce,
-		rank > 0 ? SubTreeNode(rank) : TopTreeNode(rank),
-		pipe, ifsorted)
+    reducedvalue(freduce,
+        rank > 0 ? SubTreeNode(rank) : TopTreeNode(rank),
+        pipe, ifsorted)
 end
 
 function reducedvalue(freduce::Function, node::SubTreeNode,
-	pipe::BranchChannel{Tmap,Tred}, ::Unsorted) where {Tmap,Tred}
+    pipe::BranchChannel{Tmap,Tred}, ::Unsorted) where {Tmap,Tred}
 
-	self = take!(pipe.selfchannels.out) :: Tmap
-	N = nchildren(pipe)
-	vals = Vector{Tred}(undef, N + 1)
-	
-	vals[1] = freduce((self,)) :: Tred
-	
-	for i = 1:N
-		vals[i+1] = take!(pipe.childrenchannels.out)::Tred
-	end
-	
-	freduce(vals)
+    self = take!(pipe.selfchannels.out) :: Tmap
+    N = nchildren(pipe)
+    vals = Vector{Tred}(undef, N + 1)
+    
+    vals[1] = freduce((self,)) :: Tred
+    
+    for i = 1:N
+        vals[i+1] = take!(pipe.childrenchannels.out)::Tred
+    end
+    
+    freduce(vals)
 end
 function reducedvalue(freduce::Function, node::TopTreeNode,
-	pipe::BranchChannel{<:Any,Tred}, ::Unsorted) where {Tred}
+    pipe::BranchChannel{<:Any,Tred}, ::Unsorted) where {Tred}
 
-	N = nchildren(pipe)
-	if N == 0
-		# shouldn't reach this
-		error("Nodes on the top tree must have children")
-	end
-	
-	vals = Vector{Tred}(undef, N)
-	
-	for i = 1:N
-		vals[i] = take!(pipe.childrenchannels.out)::Tred
-	end
+    N = nchildren(pipe)
+    if N == 0
+        # shouldn't reach this
+        error("Nodes on the top tree must have children")
+    end
+    
+    vals = Vector{Tred}(undef, N)
+    
+    for i = 1:N
+        vals[i] = take!(pipe.childrenchannels.out)::Tred
+    end
 
-	freduce(vals)
+    freduce(vals)
 end
 
 function reducedvalue(freduce::Function, node::SubTreeNode,
-	pipe::BranchChannel{Tmap,Tred}, ::Sorted) where {Tmap,Tred}
+    pipe::BranchChannel{Tmap,Tred}, ::Sorted) where {Tmap,Tred}
 
-	rank = node.rank
-	N = nchildren(pipe)
-	leftchild = N > 0
-	vals = Vector{Tred}(undef, N + 1)
-	
-	selfval = take!(pipe.selfchannels.out)::Tmap
-	selfvalred = freduce((value(selfval),))
-	pv = pval(rank,selfvalred)
-	ind = leftchild + 1
-	vals[ind] = pv
+    rank = node.rank
+    N = nchildren(pipe)
+    leftchild = N > 0
+    vals = Vector{Tred}(undef, N + 1)
+    
+    selfval = take!(pipe.selfchannels.out)::Tmap
+    selfvalred = freduce((value(selfval),))
+    pv = pval(rank,selfvalred)
+    ind = leftchild + 1
+    vals[ind] = pv
 
-	for i = 1:N
-		pv = take!(pipe.childrenchannels.out) :: Tred
-		shift = pv.rank > rank ? 1 : -1
-		ind = shift + leftchild + 1
-		vals[ind] = pv
-	end
+    for i = 1:N
+        pv = take!(pipe.childrenchannels.out) :: Tred
+        shift = pv.rank > rank ? 1 : -1
+        ind = shift + leftchild + 1
+        vals[ind] = pv
+    end
 
-	Tred(rank, freduce(value(v) for v in vals))
+    Tred(rank, freduce(value(v) for v in vals))
 end
 function reducedvalue(freduce::Function, node::TopTreeNode,
-	pipe::BranchChannel{<:Any,Tred}, ::Sorted) where {Tred}
+    pipe::BranchChannel{<:Any,Tred}, ::Sorted) where {Tred}
 
-	rank = node.rank
-	N = nchildren(pipe)
-	if N == 0
-		# shouldn't reach this
-		error("Nodes on the top tree must have children")
-	end
+    rank = node.rank
+    N = nchildren(pipe)
+    if N == 0
+        # shouldn't reach this
+        error("Nodes on the top tree must have children")
+    end
 
-	vals = Vector{Tred}(undef, N)
+    vals = Vector{Tred}(undef, N)
 
-	for i = 1:N
-		pv = take!(pipe.childrenchannels.out) :: Tred
-		vals[i] = pv
-	end
+    for i = 1:N
+        pv = take!(pipe.childrenchannels.out) :: Tred
+        vals[i] = pv
+    end
 
-	sort!(vals, by = pv -> pv.rank)
+    sort!(vals, by = pv -> pv.rank)
 
-	Tred(rank, freduce(value(v) for v in vals))
+    Tred(rank, freduce(value(v) for v in vals))
 end
 
 function indicatereduceprogress!(::Nothing,rank) end
 function indicatereduceprogress!(progress::RemoteChannel,rank)
-	put!(progress,(false,true,rank))
+    put!(progress,(false,true,rank))
 end
 
 function reduceTreeNode(freduce::Function, rank, pipe::BranchChannel,
-	ifsort::Ordering, progress)
-	
-	reduceTreeNode(freduce,
-		rank > 0 ? SubTreeNode(rank) : TopTreeNode(rank),
-		pipe, ifsort, progress)
+    ifsort::Ordering, progress)
+    
+    reduceTreeNode(freduce,
+        rank > 0 ? SubTreeNode(rank) : TopTreeNode(rank),
+        pipe, ifsort, progress)
 end
 
 function checkerror(::SubTreeNode, pipe::BranchChannel)
-	selferr = take!(pipe.selfchannels.err)
-	childrenerr = any(take!(pipe.childrenchannels.err) for i=1:nchildren(pipe))
-	selferr || childrenerr
+    selferr = take!(pipe.selfchannels.err)
+    childrenerr = any(take!(pipe.childrenchannels.err) for i=1:nchildren(pipe))
+    selferr || childrenerr
 end
 function checkerror(::TopTreeNode, pipe::BranchChannel)
-	any(take!(pipe.childrenchannels.err) for i=1:nchildren(pipe))
+    any(take!(pipe.childrenchannels.err) for i=1:nchildren(pipe))
 end
 
 function reduceTreeNode(freduce::Function, node::ReductionNode,
-	pipe::BranchChannel{<:Any,Tred},
-	ifsort::Ordering, progress::Union{Nothing,RemoteChannel}) where {Tred}
-	# This function that communicates with the parent and children
+    pipe::BranchChannel{<:Any,Tred},
+    ifsort::Ordering, progress::Union{Nothing,RemoteChannel}) where {Tred}
+    # This function that communicates with the parent and children
 
-	# Start by checking if there is any error locally in the map,
-	# and if there's none then check if there are any errors on the children
-	anyerr = checkerror(node, pipe)
-	rank = node.rank
-	# Evaluate the reduction only if there's no error
-	# In either case push the error flag to the parent
-	if !anyerr
-		try
-			res = reducedvalue(freduce, node, pipe, ifsort) :: Tred
-			put!(pipe.parentchannels.out, res)
-			put!(pipe.parentchannels.err, false)
-			indicatereduceprogress!(progress, rank)
-		catch e
-			put!(pipe.parentchannels.err, true)
-			indicatefailure!(progress, rank)
-			rethrow()
-		end
-	else
-		put!(pipe.parentchannels.err, true)
-		indicatefailure!(progress, rank)
-	end
+    # Start by checking if there is any error locally in the map,
+    # and if there's none then check if there are any errors on the children
+    anyerr = checkerror(node, pipe)
+    rank = node.rank
+    # Evaluate the reduction only if there's no error
+    # In either case push the error flag to the parent
+    if !anyerr
+        try
+            res = reducedvalue(freduce, node, pipe, ifsort) :: Tred
+            put!(pipe.parentchannels.out, res)
+            put!(pipe.parentchannels.err, false)
+            indicatereduceprogress!(progress, rank)
+        catch e
+            put!(pipe.parentchannels.err, true)
+            indicatefailure!(progress, rank)
+            rethrow()
+        end
+    else
+        put!(pipe.parentchannels.err, true)
+        indicatefailure!(progress, rank)
+    end
 
-	finalize(pipe)
+    finalize(pipe)
 end
 
 function return_unless_error(r::RemoteChannelContainer)
-	anyerror = take!(r.err)
-	if !anyerror
-		return value(take!(r.out))
-	end
+    anyerror = take!(r.err)
+    if !anyerror
+        return value(take!(r.out))
+    end
 end
 
 function return_unless_error(b::BranchChannel)
-	return_unless_error(b.parentchannels)
+    return_unless_error(b.parentchannels)
 end
 
 function pmapreduceworkers(fmap::Function, freduce::Function, iterators::Tuple,
-	tree, branches, ord::Ordering, args...;
-	showprogress::Bool = false, progressdesc = "Progress in pmapreduce : ",
-	kwargs...)
+    tree, branches, ord::Ordering, args...;
+    showprogress::Bool = false, progressdesc = "Progress in pmapreduce : ",
+    kwargs...)
 
-	num_workers_active = nworkersactive(iterators)
-	Nmaptotal = num_workers_active
-	Nreducetotal = length(branches)
-	extrareducenodes = Nreducetotal - Nmaptotal
-	
-	Nprogress = Nmaptotal+Nreducetotal
-	progresschannel = RemoteChannel(()->Channel{Tuple{Bool,Bool,Int}}(
-						ifelse(showprogress,Nprogress,0)))
-	progressbar = Progress(Nprogress,1,progressdesc)
+    num_workers_active = nworkersactive(iterators)
+    Nmaptotal = num_workers_active
+    Nreducetotal = length(branches)
+    extrareducenodes = Nreducetotal - Nmaptotal
+    
+    Nprogress = Nmaptotal+Nreducetotal
+    progresschannel = RemoteChannel(()->Channel{Tuple{Bool,Bool,Int}}(
+                        ifelse(showprogress,Nprogress,0)))
+    progressbar = Progress(Nprogress,1,progressdesc)
 
-	@sync begin
+    @sync begin
 
-		for (ind,mypipe) in enumerate(branches)
-			p = mypipe.p
-			ind_reduced = ind - extrareducenodes
-			rank = ind_reduced
-			if ind_reduced > 0
-				iterable_on_proc = ProductSplit(iterators,num_workers_active,rank)
+        for (ind,mypipe) in enumerate(branches)
+            p = mypipe.p
+            ind_reduced = ind - extrareducenodes
+            rank = ind_reduced
+            if ind_reduced > 0
+                iterable_on_proc = ProductSplit(iterators,num_workers_active,rank)
 
-				@spawnat p mapTreeNode(fmap, iterable_on_proc, rank, mypipe,
-					showprogress ? progresschannel : nothing,
-					args...;kwargs...)
+                @spawnat p mapTreeNode(fmap, iterable_on_proc, rank, mypipe,
+                    showprogress ? progresschannel : nothing,
+                    args...;kwargs...)
 
-				@spawnat p reduceTreeNode(freduce, SubTreeNode(rank),
-					mypipe, ord, showprogress ? progresschannel : nothing)
-			else
-				@spawnat p reduceTreeNode(freduce, TopTreeNode(rank),
-					mypipe, ord, showprogress ? progresschannel : nothing)
-			end
-		end
+                @spawnat p reduceTreeNode(freduce, SubTreeNode(rank),
+                    mypipe, ord, showprogress ? progresschannel : nothing)
+            else
+                @spawnat p reduceTreeNode(freduce, TopTreeNode(rank),
+                    mypipe, ord, showprogress ? progresschannel : nothing)
+            end
+        end
 
-		if showprogress
+        if showprogress
 
-			mapdone,reducedone = 0,0
+            mapdone,reducedone = 0,0
 
-			for i = 1:Nprogress
-				mapflag,redflag,rank = take!(progresschannel)
-				# both flags are false in case of an error
-				mapflag || redflag || break
+            for i = 1:Nprogress
+                mapflag,redflag,rank = take!(progresschannel)
+                # both flags are false in case of an error
+                mapflag || redflag || break
 
-				mapdone += mapflag
-				reducedone += redflag
+                mapdone += mapflag
+                reducedone += redflag
 
-				if mapdone != Nmaptotal && reducedone != Nreducetotal
-					showvalues = [
-					(:map, string(mapdone)*"/"*string(Nmaptotal)),
-					(:reduce, string(reducedone)*"/"*string(Nreducetotal))
-					]
+                if mapdone != Nmaptotal && reducedone != Nreducetotal
+                    showvalues = [
+                    (:map, string(mapdone)*"/"*string(Nmaptotal)),
+                    (:reduce, string(reducedone)*"/"*string(Nreducetotal))
+                    ]
 
-				elseif reducedone != Nreducetotal
-					showvalues = [
-					(:reduce, string(reducedone)*"/"*string(Nreducetotal))
-					]
-				else
-					showvalues = []
-				end
+                elseif reducedone != Nreducetotal
+                    showvalues = [
+                    (:reduce, string(reducedone)*"/"*string(Nreducetotal))
+                    ]
+                else
+                    showvalues = []
+                end
 
-				next!(progressbar;showvalues=showvalues)
-			end
-		end
-	end
+                next!(progressbar;showvalues=showvalues)
+            end
+        end
+    end
 
-	return_unless_error(topbranch(tree,branches))
+    return_unless_error(topbranch(tree,branches))
 end
 
 """
-	pmapreduce_commutative(fmap, freduce, iterators, [mapargs...]; 
-		<keyword arguments>, [mapkwargs...])
+    pmapreduce_commutative(fmap, freduce, iterators, [mapargs...]; 
+        <keyword arguments>, [mapkwargs...])
 
 Evaluate a parallel mapreduce over the range spanned by 
 the outer product of the iterators. The operation
@@ -312,8 +312,8 @@ as `Base.splat(op)` or wrap it in an anonymous function as `x -> op(x...)`.
 Arguments `mapargs` and keyword arguments `mapkwargs` — if provided — are 
 passed on to the mapping function `fmap`.
 
-	pmapreduce_commutative(fmap, Tmap, freduce, Treduce, iterators, [mapargs...]; 
-		<keyword arguments>, [mapkwargs...])
+    pmapreduce_commutative(fmap, Tmap, freduce, Treduce, iterators, [mapargs...]; 
+        <keyword arguments>, [mapkwargs...])
 
 The types `Tmap` and `Treduce` are the return types of the map and 
 reduce operations respectively. The returned values will be coerced to 
@@ -327,35 +327,35 @@ the specified types if possible, throwing an error otherwise.
 See also: [`pmapreduce_commutative_elementwise`](@ref), [`pmapreduce`](@ref), [`pmapsum`](@ref)
 """
 function pmapreduce_commutative(fmap::Function, Tmap::Type,
-	freduce::Function, Tred::Type, iterators::Tuple, args...;
-	kwargs...)
-	
-	tree,branches = createbranchchannels(Tmap,Tred,iterators,
-		SegmentedSequentialBinaryTree)
-	
-	pmapreduceworkers(fmap, freduce, iterators, tree,
-		branches, Unsorted(), args...;kwargs...)
+    freduce::Function, Tred::Type, iterators::Tuple, args...;
+    kwargs...)
+    
+    tree,branches = createbranchchannels(Tmap,Tred,iterators,
+        SegmentedSequentialBinaryTree)
+    
+    pmapreduceworkers(fmap, freduce, iterators, tree,
+        branches, Unsorted(), args...;kwargs...)
 end
 
 function pmapreduce_commutative(fmap::Function, freduce::Function,
-	iterators::Tuple, args...;kwargs...)
+    iterators::Tuple, args...;kwargs...)
 
-	pmapreduce_commutative(fmap, Any, freduce, Any, iterators, args...;kwargs...)
+    pmapreduce_commutative(fmap, Any, freduce, Any, iterators, args...;kwargs...)
 end
 
 function pmapreduce_commutative(fmap::Function, Tmap::Type,
-	freduce::Function, Tred::Type, iterable, args...;kwargs...)
+    freduce::Function, Tred::Type, iterable, args...;kwargs...)
 
-	pmapreduce_commutative(fmap, Tmap, freduce, Tred, (iterable,), args...;kwargs...)
+    pmapreduce_commutative(fmap, Tmap, freduce, Tred, (iterable,), args...;kwargs...)
 end
 
 function pmapreduce_commutative(fmap::Function, freduce::Function, iterable, args...;kwargs...)
-	pmapreduce_commutative(fmap, freduce, (iterable,), args...;kwargs...)
+    pmapreduce_commutative(fmap, freduce, (iterable,), args...;kwargs...)
 end
 
 """
-	pmapreduce_commutative_elementwise(fmap, freduce, iterators, [mapargs...]; 
-		<keyword arguments>, [mapkwargs...])
+    pmapreduce_commutative_elementwise(fmap, freduce, iterators, [mapargs...]; 
+        <keyword arguments>, [mapkwargs...])
 
 Evaluate a parallel mapreduce over the range spanned by 
 the outer product of the iterators. 
@@ -374,8 +374,8 @@ as `Base.splat(op)` or wrap it in an anonymous function as `x -> op(x...)`.
 Arguments `mapargs` and keyword arguments `mapkwargs` — if provided — are 
 passed on to the mapping function `fmap`.
 
-	pmapreduce_commutative_elementwise(fmap, Tmap, freduce, Treduce, iterators, [mapargs...]; 
-		<keyword arguments>, [mapkwargs...])
+    pmapreduce_commutative_elementwise(fmap, Tmap, freduce, Treduce, iterators, [mapargs...]; 
+        <keyword arguments>, [mapkwargs...])
 
 The types `Tmap` and `Treduce` are the return types of the map and 
 reduce operations respectively. The returned values will be coerced to 
@@ -389,29 +389,29 @@ the specified types if possible, throwing an error otherwise.
 See also: [`pmapreduce_commutative`](@ref)
 """
 function pmapreduce_commutative_elementwise(fmap::Function, Tmap::Type,
-	freduce::Function, Tred::Type, iterable, args...;
-	showprogress::Bool = false, progressdesc = "Progress in pmapreduce : ",
-	kwargs...)
-	
-	pmapreduce_commutative(
-		plist->freduce((fmap(x...,args...;kwargs...) for x in plist)),
-		Tred,freduce,Tred,iterable,
-		showprogress = showprogress, progressdesc = progressdesc)
+    freduce::Function, Tred::Type, iterable, args...;
+    showprogress::Bool = false, progressdesc = "Progress in pmapreduce : ",
+    kwargs...)
+    
+    pmapreduce_commutative(
+        plist->freduce((fmap(x...,args...;kwargs...) for x in plist)),
+        Tred,freduce,Tred,iterable,
+        showprogress = showprogress, progressdesc = progressdesc)
 end
 
 function pmapreduce_commutative_elementwise(fmap::Function, freduce::Function, iterable, args...;
-	showprogress::Bool = false, progressdesc = "Progress in pmapreduce : ",
-	kwargs...)
+    showprogress::Bool = false, progressdesc = "Progress in pmapreduce : ",
+    kwargs...)
 
-	pmapreduce_commutative(
-		plist->freduce((fmap(x...,args...;kwargs...) for x in plist)),
-		freduce,iterable,
-		showprogress = showprogress, progressdesc = progressdesc)
+    pmapreduce_commutative(
+        plist->freduce((fmap(x...,args...;kwargs...) for x in plist)),
+        freduce,iterable,
+        showprogress = showprogress, progressdesc = progressdesc)
 end
 
 """
-	pmapsum(fmap, iterators, [mapargs...]; 
-		<keyword arguments>, [mapkwargs...])
+    pmapsum(fmap, iterators, [mapargs...]; 
+        <keyword arguments>, [mapkwargs...])
 
 Evaluate a parallel mapreduce over the range spanned by 
 the outer product of the iterators, where the reduction operation
@@ -427,8 +427,8 @@ or iterate over one to access individual tuples of integers.
 Arguments `mapargs` and keyword arguments `mapkwargs` — if provided — are 
 passed on to the mapping function `fmap`.
 
-	pmapsum(fmap, Tmap, iterators, [mapargs...]; 
-		<keyword arguments>, [mapkwargs...])
+    pmapsum(fmap, Tmap, iterators, [mapargs...]; 
+        <keyword arguments>, [mapkwargs...])
 
 The types `Tmap` is the return types of the map. 
 The returned values will be coerced to 
@@ -442,18 +442,18 @@ the specified type if possible, throwing an error otherwise.
 See also: [`pmapreduce`](@ref), [`pmapreduce_commutative`](@ref)
 """
 function pmapsum(fmap::Function, T::Type, iterable, args...;kwargs...)
-	pmapreduce_commutative(fmap, T, sum, T, iterable, args...;
-		progressdesc = "Progress in pmapsum : ", kwargs...)
+    pmapreduce_commutative(fmap, T, sum, T, iterable, args...;
+        progressdesc = "Progress in pmapsum : ", kwargs...)
 end
 
 function pmapsum(fmap::Function, iterable, args...;kwargs...)
-	pmapreduce_commutative(fmap, sum, iterable, args...;
-		progressdesc = "Progress in pmapsum : ", kwargs...)
+    pmapreduce_commutative(fmap, sum, iterable, args...;
+        progressdesc = "Progress in pmapsum : ", kwargs...)
 end
 
 """
-	pmapsum_elementwise(fmap, iterators, [mapargs...]; 
-		<keyword arguments>, [mapkwargs...])
+    pmapsum_elementwise(fmap, iterators, [mapargs...]; 
+        <keyword arguments>, [mapkwargs...])
 
 Evaluate a parallel mapreduce over the range spanned by 
 the outer product of the iterators, where the reduction operation is a sum. 
@@ -464,8 +464,8 @@ over the entire range of parameters.
 Arguments `mapargs` and keyword arguments `mapkwargs` — if provided — are 
 passed on to the mapping function `fmap`.
 
-	pmapsum_elementwise(fmap, Tmap, iterators, [mapargs...]; 
-		<keyword arguments>, [mapkwargs...])
+    pmapsum_elementwise(fmap, Tmap, iterators, [mapargs...]; 
+        <keyword arguments>, [mapkwargs...])
 
 The type `Tmap` is the return type of the map. 
 The returned values will be coerced to 
@@ -479,24 +479,24 @@ the specified type if possible, throwing an error otherwise.
 See also: [`pmapreduce_commutative_elementwise`](@ref), [`pmapsum`](@ref)
 """
 function pmapsum_elementwise(fmap::Function, T::Type, iterable,args...;
-	showprogress::Bool = false, progressdesc = "Progress in pmapsum : ",
-	kwargs...)
+    showprogress::Bool = false, progressdesc = "Progress in pmapsum : ",
+    kwargs...)
 
-	pmapsum(plist->sum(x->fmap(x...,args...;kwargs...),plist),T,iterable,
-		showprogress = showprogress, progressdesc = progressdesc)
+    pmapsum(plist->sum(x->fmap(x...,args...;kwargs...),plist),T,iterable,
+        showprogress = showprogress, progressdesc = progressdesc)
 end
 
 function pmapsum_elementwise(fmap::Function, iterable, args...;
-	showprogress::Bool = false, progressdesc = "Progress in pmapsum : ",
-	kwargs...)
+    showprogress::Bool = false, progressdesc = "Progress in pmapsum : ",
+    kwargs...)
 
-	pmapsum(plist->sum(x->fmap(x...,args...;kwargs...),plist),iterable,
-		showprogress = showprogress, progressdesc = progressdesc)
+    pmapsum(plist->sum(x->fmap(x...,args...;kwargs...),plist),iterable,
+        showprogress = showprogress, progressdesc = progressdesc)
 end
 
 """
-	pmapreduce(fmap, freduce, iterators, [mapargs...]; 
-		<keyword arguments>, [mapkwargs...])
+    pmapreduce(fmap, freduce, iterators, [mapargs...]; 
+        <keyword arguments>, [mapkwargs...])
 
 Evaluate a parallel mapreduce over the range spanned by 
 the outer product of the iterators.
@@ -517,8 +517,8 @@ as `Base.splat(op)` or wrap it in an anonymous function as `x -> op(x...)`.
 Arguments `mapargs` and keyword arguments `mapkwargs` — if provided — are 
 passed on to the mapping function `fmap`.
 
-	pmapreduce(fmap, Tmap, freduce, Treduce, iterators, [mapargs...]; 
-		<keyword arguments>, [mapkwargs...])
+    pmapreduce(fmap, Tmap, freduce, Treduce, iterators, [mapargs...]; 
+        <keyword arguments>, [mapkwargs...])
 
 The types `Tmap` and `Treduce` are the return types of the map and 
 reduce operations respectively. The returned values will be coerced to 
@@ -532,29 +532,29 @@ the specified types if possible, throwing an error otherwise.
 See also: [`pmapreduce_commutative`](@ref), [`pmapsum`](@ref)
 """
 function pmapreduce(fmap::Function, Tmap::Type, freduce::Function, Tred::Type,
-	iterators::Tuple, args...;kwargs...)
+    iterators::Tuple, args...;kwargs...)
 
-	tree,branches = createbranchchannels(pval{Tmap},pval{Tred},
-		iterators, SegmentedOrderedBinaryTree)
-	
-	pmapreduceworkers(fmap, freduce, iterators, tree,
-		branches, Sorted(), args...;kwargs...)
+    tree,branches = createbranchchannels(pval{Tmap},pval{Tred},
+        iterators, SegmentedOrderedBinaryTree)
+    
+    pmapreduceworkers(fmap, freduce, iterators, tree,
+        branches, Sorted(), args...;kwargs...)
 end
 
 function pmapreduce(fmap::Function, freduce::Function, iterators::Tuple, args...;
-	kwargs...)
+    kwargs...)
 
-	pmapreduce(fmap, Any, freduce, Any, iterators, args...;kwargs...)
+    pmapreduce(fmap, Any, freduce, Any, iterators, args...;kwargs...)
 end
 
 function pmapreduce(fmap::Function, Tmap::Type, freduce::Function, Tred::Type,
-	iterable, args...;kwargs...)
-	
-	pmapreduce(fmap, Tmap, freduce, Tred, (iterable,), args...;kwargs...)
+    iterable, args...;kwargs...)
+    
+    pmapreduce(fmap, Tmap, freduce, Tred, (iterable,), args...;kwargs...)
 end
 
 function pmapreduce(fmap::Function, freduce::Function, iterable, args...;kwargs...)
-	pmapreduce(fmap, freduce, (iterable,), args...;kwargs...)
+    pmapreduce(fmap, freduce, (iterable,), args...;kwargs...)
 end
 
 ############################################################################################
@@ -562,8 +562,8 @@ end
 ############################################################################################
 
 """
-	pmapbatch(f, iterators, [mapargs...]; 
-		[num_workers::Int = nworkersactive(iterators)], [mapkwargs...])
+    pmapbatch(f, iterators, [mapargs...]; 
+        [num_workers::Int = nworkersactive(iterators)], [mapkwargs...])
 
 Evaluate the function `f` in parallel, where each worker gets a 
 part of the entire parameter space sequentially. The argument 
@@ -577,8 +577,8 @@ Additionally, the number of workers to be used may be specified using the
 keyword argument `num_workers`. In this case the first `num_workers` available
 workers are used in the evaluation.
 
-	pmapbatch(f, T::Type, iterators, [mapargs...];
-		[num_workers::Int = nworkersactive(iterators)], [mapkwargs...])
+    pmapbatch(f, T::Type, iterators, [mapargs...];
+        [num_workers::Int = nworkersactive(iterators)], [mapkwargs...])
 
 Evaluate `f` in parallel, and convert the returned value to type `T`. 
 The method is type stable if `T` is concrete.
@@ -587,43 +587,43 @@ Values returned by `f` will be type-coerced if possible, and an error will be ra
 See also: [`pmapreduce`](@ref), [`pmapsum`](@ref)
 """
 function pmapbatch(f::Function, iterators::Tuple, args...;
-	num_workers = nworkersactive(iterators),kwargs...)
+    num_workers = nworkersactive(iterators),kwargs...)
 
-	pmapbatch(f, Any, iterators, args...; num_workers = num_workers, kwargs...)
+    pmapbatch(f, Any, iterators, args...; num_workers = num_workers, kwargs...)
 end
 
 function pmapbatch(f::Function, ::Type{T}, iterators::Tuple, args...;
-	num_workers = nworkersactive(iterators), kwargs...) where {T}
+    num_workers = nworkersactive(iterators), kwargs...) where {T}
 
-	procs_used = workersactive(iterators)
-	if num_workers < length(procs_used)
-		procs_used = procs_used[1:num_workers]
-	end
-	num_workers = length(procs_used)
+    procs_used = workersactive(iterators)
+    if num_workers < length(procs_used)
+        procs_used = procs_used[1:num_workers]
+    end
+    num_workers = length(procs_used)
 
-	res = Vector{T}(undef, num_workers)
+    res = Vector{T}(undef, num_workers)
 
-	@sync for (rank,p) in enumerate(procs_used)
-		@async begin
-			iterable_on_proc = ProductSplit(iterators, num_workers, rank)
-			res[rank] = @fetchfrom p f(iterable_on_proc, args...;kwargs...)
-		end
-	end
-	
-	vcat(res...)
+    @sync for (rank,p) in enumerate(procs_used)
+        @async begin
+            iterable_on_proc = ProductSplit(iterators, num_workers, rank)
+            res[rank] = @fetchfrom p f(iterable_on_proc, args...;kwargs...)
+        end
+    end
+    
+    vcat(res...)
 end
 
 function pmapbatch(f::Function, T::Type, iterable, args...;kwargs...)
-	pmapbatch(f, T, (iterable,), args...;kwargs...)
+    pmapbatch(f, T, (iterable,), args...;kwargs...)
 end
 
 function pmapbatch(f::Function, iterable, args...;kwargs...)
-	pmapbatch(f, (iterable,), args...;kwargs...)
+    pmapbatch(f, (iterable,), args...;kwargs...)
 end
 
 """
-	pmapbatch_elementwise(f, iterators, [mapargs...]; 
-		[num_workers::Int = nworkersactive(iterators)], [mapkwargs...])
+    pmapbatch_elementwise(f, iterators, [mapargs...]; 
+        [num_workers::Int = nworkersactive(iterators)], [mapkwargs...])
 
 Evaluate the function `f` in parallel, where each worker gets a 
 part of the entire parameter space sequentially. The argument 
@@ -643,8 +643,8 @@ workers are used in the evaluation.
 See also: [`pmapbatch`](@ref)
 """
 function pmapbatch_elementwise(f::Function, iterators, args...;
-	num_workers = nworkersactive(iterators), kwargs...)
+    num_workers = nworkersactive(iterators), kwargs...)
 
-	pmapbatch(plist->asyncmap(x->f(x...,args...;kwargs...),plist),
-		iterators,num_workers=num_workers)
+    pmapbatch(plist->asyncmap(x->f(x...,args...;kwargs...),plist),
+        iterators,num_workers=num_workers)
 end

--- a/src/productsplit.jl
+++ b/src/productsplit.jl
@@ -1,5 +1,5 @@
 """
-	ParallelUtilities.AbstractConstrainedProduct{T,N}
+    ParallelUtilities.AbstractConstrainedProduct{T,N}
 
 Supertype of [`ParallelUtilities.ProductSplit`](@ref) and [`ParallelUtilities.ProductSection`](@ref).
 """
@@ -8,7 +8,7 @@ Base.eltype(::AbstractConstrainedProduct{T}) where {T} = T
 Base.ndims(::AbstractConstrainedProduct{<:Any,N}) where {N} = N
 
 """
-	ProductSplit{T,N,Q}
+    ProductSplit{T,N,Q}
 
 Iterator that loops over the outer product of ranges in 
 reverse-lexicographic order. The ranges need to be strictly
@@ -19,32 +19,32 @@ a tuple of length `N` with one element from each range.
 See also: [`ProductSection`](@ref)
 """
 struct ProductSplit{T,N,Q} <: AbstractConstrainedProduct{T,N}
-	iterators :: Q
-	togglelevels :: NTuple{N,Int}
-	np :: Int
-	p :: Int
-	firstind :: Int
-	lastind :: Int
+    iterators :: Q
+    togglelevels :: NTuple{N,Int}
+    np :: Int
+    p :: Int
+    firstind :: Int
+    lastind :: Int
 
-	function ProductSplit(iterators::Tuple{Vararg{AbstractRange,N}},togglelevels::NTuple{N,Int},
-		np::Int,p::Int,firstind::Int,lastind::Int) where {N}
+    function ProductSplit(iterators::Tuple{Vararg{AbstractRange,N}},togglelevels::NTuple{N,Int},
+        np::Int,p::Int,firstind::Int,lastind::Int) where {N}
 
-		1 <= p <= np || throw(ProcessorNumberError(p,np))
-		T = Tuple{map(eltype,iterators)...}
-		Q = typeof(iterators)
+        1 <= p <= np || throw(ProcessorNumberError(p,np))
+        T = Tuple{map(eltype,iterators)...}
+        Q = typeof(iterators)
 
-		# Ensure that all the iterators are strictly increasing
-		all(x->step(x)>0,iterators) || 
-		throw(ArgumentError("all the iterators need to be strictly increasing"))
+        # Ensure that all the iterators are strictly increasing
+        all(x->step(x)>0,iterators) || 
+        throw(ArgumentError("all the iterators need to be strictly increasing"))
 
-		new{T,N,Q}(iterators,togglelevels,np,p,firstind,lastind)
-	end
+        new{T,N,Q}(iterators,togglelevels,np,p,firstind,lastind)
+    end
 end
 
 workerrank(ps::ProductSplit) = ps.p
 
 """
-	ProductSection{T,N,Q}
+    ProductSection{T,N,Q}
 
 Iterator that loops over a specified section of the 
 outer product of the ranges provided in 
@@ -56,55 +56,57 @@ a tuple of length `N` with one element from each range.
 See also: [`ProductSplit`](@ref)
 """
 struct ProductSection{T,N,Q} <: AbstractConstrainedProduct{T,N}
-	iterators :: Q
-	togglelevels :: NTuple{N,Int}
-	firstind :: Int
-	lastind :: Int
+    iterators :: Q
+    togglelevels :: NTuple{N,Int}
+    firstind :: Int
+    lastind :: Int
 
-	function ProductSection(iterators::Tuple{Vararg{AbstractRange,N}},togglelevels::NTuple{N,Int},
-		firstind::Int,lastind::Int) where {N}
+    function ProductSection(iterators::Tuple{Vararg{AbstractRange,N}},togglelevels::NTuple{N,Int},
+        firstind::Int,lastind::Int) where {N}
 
-		T = Tuple{eltype.(iterators)...}
-		Q = typeof(iterators)
+        T = Tuple{eltype.(iterators)...}
+        Q = typeof(iterators)
 
-		# Ensure that all the iterators are strictly increasing
-		all(x->step(x)>0,iterators) || 
-		throw(ArgumentError("all the iterators need to be strictly increasing"))
+        # Ensure that all the iterators are strictly increasing
+        all(x->step(x)>0,iterators) || 
+        throw(ArgumentError("all the iterators need to be strictly increasing"))
 
-		new{T,N,Q}(iterators,togglelevels,firstind,lastind)
-	end
+        new{T,N,Q}(iterators,togglelevels,firstind,lastind)
+    end
 end
 
 function mwerepr(ps::ProductSplit)
-	"ProductSplit("*repr(ps.iterators)*", "*repr(ps.np)*", "*repr(ps.p)*")"
+    "ProductSplit("*repr(ps.iterators)*", "*repr(ps.np)*", "*repr(ps.p)*")"
 end
 function Base.summary(io::IO, ps::ProductSplit)
-	print(io, length(ps),"-element ", mwerepr(ps))
+    print(io, length(ps),"-element ", mwerepr(ps))
 end
 function Base.show(io::IO, ps::ProductSplit)
-	print(io, mwerepr(ps))
+    print(io, mwerepr(ps))
 end
 
 function _cumprod(len::Tuple)
-	(0,_cumprod(first(len),Base.tail(len))...)
+    (0,_cumprod(first(len),Base.tail(len))...)
 end
 
 _cumprod(::Integer,::Tuple{}) = ()
 function _cumprod(n::Integer, tl::Tuple)
-	(n,_cumprod(n*first(tl),Base.tail(tl))...)
+    (n,_cumprod(n*first(tl),Base.tail(tl))...)
 end
 
+@deprecate ntasks(x::Tuple) prod(length, x)
+
 """
-	ntasks(iterators::Tuple)
+    ntasks(iterators::Tuple)
 
 The total number of elements in the outer product of the ranges contained in 
-`iterators`, equal to `prod(length.(iterators))`
+`iterators`, equal to `prod(length, iterators)`
 """
-ntasks(iterators::Tuple) = mapreduce(length,*,iterators)
+ntasks
 ntasks(ps::AbstractConstrainedProduct) = ntasks(ps.iterators)
 
 """
-	ProductSplit(iterators::Tuple{Vararg{AbstractRange}}, np::Integer, p::Integer)
+    ProductSplit(iterators::Tuple{Vararg{AbstractRange}}, np::Integer, p::Integer)
 
 Construct a `ProductSplit` iterator that represents the outer product 
 of the iterators split over `np` workers, with this instance reprsenting 
@@ -124,18 +126,18 @@ julia> ProductSplit((1:2,4:5), 2, 2) |> collect
 ```
 """
 function ProductSplit(iterators::Tuple{Vararg{AbstractRange}}, np::Integer, p::Integer)
-	len = size.(iterators,1)
-	Nel = prod(len)
-	togglelevels = _cumprod(len)
-	d,r = divrem(Nel,np)
-	firstind = d*(p-1) + min(r,p-1) + 1
-	lastind = d*p + min(r,p)
-	ProductSplit(iterators,togglelevels,np,p,firstind,lastind)
+    len = size.(iterators,1)
+    Nel = prod(len)
+    togglelevels = _cumprod(len)
+    d,r = divrem(Nel,np)
+    firstind = d*(p-1) + min(r,p-1) + 1
+    lastind = d*p + min(r,p)
+    ProductSplit(iterators,togglelevels,np,p,firstind,lastind)
 end
 ProductSplit(::Tuple{},::Integer,::Integer) = throw(ArgumentError("Need at least one iterator"))
 
 """
-	ProductSection(iterators::Tuple{Vararg{AbstractRange}}, inds::AbstractUnitRange)
+    ProductSection(iterators::Tuple{Vararg{AbstractRange}}, inds::AbstractUnitRange)
 
 Construct a `ProductSection` iterator that represents a 1D view of the outer product
 of the ranges provided in `iterators`, with the range of indices in the view being
@@ -157,43 +159,43 @@ true
 ```
 """
 function ProductSection(iterators::Tuple{Vararg{AbstractRange}},
-	inds::AbstractUnitRange)
+    inds::AbstractUnitRange)
 
-	isempty(inds) && throw(ArgumentError("range of indices must not be empty"))
-	firstind,lastind = extrema(inds)
+    isempty(inds) && throw(ArgumentError("range of indices must not be empty"))
+    firstind,lastind = extrema(inds)
 
-	len = size.(iterators,1)
-	Nel = prod(len)
-	1 <= firstind || throw(
-		ArgumentError("the range of indices must start from a number ≥ 1"))
-	lastind <= Nel || throw(
-		ArgumentError("the maximum index must be less than or equal to the total number of elements = $Nel"))
-	togglelevels = _cumprod(len)
-	ProductSection(iterators,togglelevels,firstind,lastind)
+    len = size.(iterators,1)
+    Nel = prod(len)
+    1 <= firstind || throw(
+        ArgumentError("the range of indices must start from a number ≥ 1"))
+    lastind <= Nel || throw(
+        ArgumentError("the maximum index must be less than or equal to the total number of elements = $Nel"))
+    togglelevels = _cumprod(len)
+    ProductSection(iterators,togglelevels,firstind,lastind)
 end
 function ProductSection(::Tuple{},::AbstractUnitRange)
-	throw(ArgumentError("Need at least one iterator"))
+    throw(ArgumentError("Need at least one iterator"))
 end
 
 Base.isempty(ps::AbstractConstrainedProduct) = (ps.firstind > ps.lastind)
 
 function Base.first(ps::AbstractConstrainedProduct)
-	isempty(ps) ? nothing : @inbounds _first(ps.iterators, childindex(ps, ps.firstind)...)
+    isempty(ps) ? nothing : @inbounds _first(ps.iterators, childindex(ps, ps.firstind)...)
 end
 
 Base.@propagate_inbounds function _first(t::Tuple,ind::Integer,rest::Integer...)
-	@boundscheck (1 <= ind <= length(first(t))) || throw(BoundsError(first(t),ind))
-	(@inbounds first(t)[ind], _first(Base.tail(t),rest...)...)
+    @boundscheck (1 <= ind <= length(first(t))) || throw(BoundsError(first(t),ind))
+    (@inbounds first(t)[ind], _first(Base.tail(t),rest...)...)
 end
 _first(::Tuple{}) = ()
 
 function Base.last(ps::AbstractConstrainedProduct)
-	isempty(ps) ? nothing : @inbounds _last(ps.iterators, childindex(ps, ps.lastind)...)
+    isempty(ps) ? nothing : @inbounds _last(ps.iterators, childindex(ps, ps.lastind)...)
 end
 
 Base.@propagate_inbounds function _last(t::Tuple, ind::Integer, rest::Integer...)
-	@boundscheck (1 <= ind <= length(first(t))) || throw(BoundsError(first(t),ind))
-	(@inbounds first(t)[ind], _last(Base.tail(t), rest...)...)
+    @boundscheck (1 <= ind <= length(first(t))) || throw(BoundsError(first(t),ind))
+    (@inbounds first(t)[ind], _last(Base.tail(t), rest...)...)
 end
 _last(::Tuple{}) = ()
 
@@ -203,7 +205,7 @@ Base.firstindex(ps::AbstractConstrainedProduct) = 1
 Base.lastindex(ps::AbstractConstrainedProduct) = ps.lastind - ps.firstind + 1
 
 """
-	ParallelUtilities.childindex(ps::AbstractConstrainedProduct, ind)
+    ParallelUtilities.childindex(ps::AbstractConstrainedProduct, ind)
 
 Return a tuple containing the indices of the individual iterators 
 corresponding to the element that is present at index `ind` in the 
@@ -225,21 +227,21 @@ true
 See also: [`childindexshifted`](@ref)
 """
 function childindex(ps::AbstractConstrainedProduct, ind)
-	tl = reverse(Base.tail(ps.togglelevels))
-	reverse(childindex(tl,ind))
+    tl = reverse(Base.tail(ps.togglelevels))
+    reverse(childindex(tl,ind))
 end
 
 function childindex(tl::Tuple, ind)
-	t = first(tl)
-	k = div(ind - 1, t)
-	(k+1,childindex(Base.tail(tl), ind - k*t)...)
+    t = first(tl)
+    k = div(ind - 1, t)
+    (k+1,childindex(Base.tail(tl), ind - k*t)...)
 end
 
 # First iterator gets the final remainder
 childindex(::Tuple{}, ind) = (ind,)
 
 """
-	ParallelUtilities.childindexshifted(ps::AbstractConstrainedProduct, ind)
+    ParallelUtilities.childindexshifted(ps::AbstractConstrainedProduct, ind)
 
 Return a tuple containing the indices in the individual iterators 
 given an index of a `AbstractConstrainedProduct`.
@@ -258,93 +260,93 @@ true
 See also: [`childindex`](@ref)
 """
 function childindexshifted(ps::AbstractConstrainedProduct, ind)
-	childindex(ps, (ind - 1) + ps.firstind)
+    childindex(ps, (ind - 1) + ps.firstind)
 end
 
 Base.@propagate_inbounds function Base.getindex(ps::AbstractConstrainedProduct, ind)
-	@boundscheck 1 <= ind <= length(ps) || throw(BoundsError(ps,ind))
-	_getindex(ps, childindexshifted(ps, ind)...)
+    @boundscheck 1 <= ind <= length(ps) || throw(BoundsError(ps,ind))
+    _getindex(ps, childindexshifted(ps, ind)...)
 end
 # This needs to be a separate function to deal with the case of a single child iterator, in which case 
 # it's not clear if the single index is for the ProductSplit or the child iterator
 
 # This method asserts that the number of indices is correct
 Base.@propagate_inbounds function _getindex(ps::AbstractConstrainedProduct{<:Any,N},
-	inds::Vararg{Integer,N}) where {N}
-	
-	_getindex(ps.iterators,inds...)
+    inds::Vararg{Integer,N}) where {N}
+    
+    _getindex(ps.iterators,inds...)
 end
 
 Base.@propagate_inbounds function _getindex(t::Tuple,ind::Integer,rest::Integer...)
-	@boundscheck (1 <= ind <= length(first(t))) || throw(BoundsError(first(t),ind))
-	(@inbounds first(t)[ind], _getindex(Base.tail(t),rest...)...)
+    @boundscheck (1 <= ind <= length(first(t))) || throw(BoundsError(first(t),ind))
+    (@inbounds first(t)[ind], _getindex(Base.tail(t),rest...)...)
 end
 _getindex(::Tuple{}, ::Integer...) = ()
 
 function Base.iterate(ps::AbstractConstrainedProduct{T}, state=(first(ps), 1)) where {T}
-	el,n = state
+    el,n = state
 
-	if n > length(ps)
-		return nothing
-	elseif n == length(ps)
-		# In this case the next value doesn't matter, so just return something arbitary
-		next_state = (el::T, n+1)
-	else
-		next_state = (ps[n+1]::T, n+1)
-	end
+    if n > length(ps)
+        return nothing
+    elseif n == length(ps)
+        # In this case the next value doesn't matter, so just return something arbitary
+        next_state = (el::T, n+1)
+    else
+        next_state = (ps[n+1]::T, n+1)
+    end
 
-	(el::T, next_state)
+    (el::T, next_state)
 end
 
 function _firstlastalongdim(ps::AbstractConstrainedProduct, dim,
-	firstindchild::Tuple = childindex(ps, ps.firstind),
-	lastindchild::Tuple = childindex(ps, ps.lastind))
+    firstindchild::Tuple = childindex(ps, ps.firstind),
+    lastindchild::Tuple = childindex(ps, ps.lastind))
 
-	iter = ps.iterators[dim]
+    iter = ps.iterators[dim]
 
-	fic = firstindchild[dim]
-	lic = lastindchild[dim]
+    fic = firstindchild[dim]
+    lic = lastindchild[dim]
 
-	first_iter = iter[fic]
-	last_iter = iter[lic]
+    first_iter = iter[fic]
+    last_iter = iter[lic]
 
-	(first_iter,last_iter)
+    (first_iter,last_iter)
 end
 
 function _checkrollover(ps::AbstractConstrainedProduct, dim,
-	firstindchild::Tuple=childindex(ps,ps.firstind),
-	lastindchild::Tuple=childindex(ps,ps.lastind))
+    firstindchild::Tuple=childindex(ps,ps.firstind),
+    lastindchild::Tuple=childindex(ps,ps.lastind))
 
-	_checkrollover(ps.iterators,dim,firstindchild,lastindchild)
+    _checkrollover(ps.iterators,dim,firstindchild,lastindchild)
 end
 
 function _checkrollover(t::Tuple, dim, firstindchild::Tuple, lastindchild::Tuple)
 
-	if dim > 0
-		return _checkrollover(Base.tail(t), dim-1, Base.tail(firstindchild), Base.tail(lastindchild))
-	end
+    if dim > 0
+        return _checkrollover(Base.tail(t), dim-1, Base.tail(firstindchild), Base.tail(lastindchild))
+    end
 
-	!_checknorollover(reverse(t), reverse(firstindchild), reverse(lastindchild))
+    !_checknorollover(reverse(t), reverse(firstindchild), reverse(lastindchild))
 end
 
 function _checknorollover(t, firstindchild, lastindchild)
-	iter = first(t)
-	first_iter = iter[first(firstindchild)]
-	last_iter = iter[first(lastindchild)]
+    iter = first(t)
+    first_iter = iter[first(firstindchild)]
+    last_iter = iter[first(lastindchild)]
 
-	(last_iter == first_iter) & 
-		_checknorollover(Base.tail(t),Base.tail(firstindchild),Base.tail(lastindchild))
+    (last_iter == first_iter) & 
+        _checknorollover(Base.tail(t),Base.tail(firstindchild),Base.tail(lastindchild))
 end
 _checknorollover(::Tuple{}, ::Tuple{}, ::Tuple{}) = true
 
 function _nrollovers(ps::AbstractConstrainedProduct, dim::Integer)
-	dim == ndims(ps) && return 0
-	nelements(ps, dim + 1) - 1
+    dim == ndims(ps) && return 0
+    nelements(ps, dim + 1) - 1
 end
 
 """
-	ParallelUtilities.nelements(ps::AbstractConstrainedProduct; dim::Integer)
-	ParallelUtilities.nelements(ps::AbstractConstrainedProduct, dim::Integer)
+    ParallelUtilities.nelements(ps::AbstractConstrainedProduct; dim::Integer)
+    ParallelUtilities.nelements(ps::AbstractConstrainedProduct, dim::Integer)
 
 Compute the number of unique values in the section of the `dim`-th range contained in `ps`.
 
@@ -374,39 +376,38 @@ julia> ParallelUtilities.nelements(ps, 3)
 """
 nelements(ps::AbstractConstrainedProduct; dim::Integer) = nelements(ps,dim)
 function nelements(ps::AbstractConstrainedProduct, dim::Integer)
-	1 <= dim <= ndims(ps) || throw(ArgumentError("1 ⩽ dim ⩽ N=$(ndims(ps)) not satisfied for dim=$dim"))
+    1 <= dim <= ndims(ps) || throw(ArgumentError("1 ⩽ dim ⩽ N=$(ndims(ps)) not satisfied for dim=$dim"))
 
-	iter = ps.iterators[dim]
+    iter = ps.iterators[dim]
 
-	if _nrollovers(ps,dim) == 0
-		st = first(ps)[dim]
-		en = last(ps)[dim]
-		stind = searchsortedfirst(iter,st)
-		enind = searchsortedfirst(iter,en)
-		nel = length(stind:enind)
-	elseif _nrollovers(ps,dim) > 1
-		nel = length(iter)
-	else
-		st = first(ps)[dim]
-		en = last(ps)[dim]
-		stind = searchsortedfirst(iter,st)
-		enind = searchsortedfirst(iter,en)
-		if stind > enind
-			# some elements are missed out
-			nel = length(stind:length(iter)) + length(1:enind)
-		else
-			nel = length(iter)
-		end
-	end
-	return nel
+    if _nrollovers(ps,dim) == 0
+        st = first(ps)[dim]
+        en = last(ps)[dim]
+        stind = searchsortedfirst(iter,st)
+        enind = searchsortedfirst(iter,en)
+        nel = length(stind:enind)
+    elseif _nrollovers(ps,dim) > 1
+        nel = length(iter)
+    else
+        st = first(ps)[dim]
+        en = last(ps)[dim]
+        stind = searchsortedfirst(iter,st)
+        enind = searchsortedfirst(iter,en)
+        if stind > enind
+            # some elements are missed out
+            nel = length(stind:length(iter)) + length(1:enind)
+        else
+            nel = length(iter)
+        end
+    end
+    return nel
 end
 
 
 """
-	maximum(ps::AbstractConstrainedProduct; dim::Integer)
-	maximum(ps::AbstractConstrainedProduct, dim::Integer)
+    maximum(ps::AbstractConstrainedProduct; dim::Integer)
 
-Compute the maximum value of the section of the `dim`-th range contained in `ps`.
+Compute the maximum value of the section of the range number `dim` contained in `ps`.
 
 # Examples
 ```jldoctest
@@ -417,50 +418,54 @@ julia> collect(ps)
  (1, 4)
  (2, 4)
 
-julia> maximum(ps,dim=1)
+julia> maximum(ps, dim = 1)
 2
 
-julia> maximum(ps,dim=2)
+julia> maximum(ps, dim = 2)
 4
 ```
 """
+function Base.maximum(ps::AbstractConstrainedProduct; dim::Integer)
+
+    isempty(ps) && return nothing
+    
+    firstindchild = childindex(ps, ps.firstind)
+    lastindchild = childindex(ps, ps.lastind)
+
+    first_iter,last_iter = _firstlastalongdim(ps, dim, firstindchild, lastindchild)
+
+    v = last_iter
+
+    # The last index will not roll over so this can be handled easily
+    if dim == ndims(ps)
+        return v
+    end
+
+    if _checkrollover(ps, dim, firstindchild, lastindchild)
+        iter = ps.iterators[dim]
+        v = maximum(iter)
+    end
+
+    return v
+end
+
 function Base.maximum(ps::AbstractConstrainedProduct, dim::Integer)
-
-	isempty(ps) && return nothing
-	
-	firstindchild = childindex(ps, ps.firstind)
-	lastindchild = childindex(ps, ps.lastind)
-
-	first_iter,last_iter = _firstlastalongdim(ps, dim, firstindchild, lastindchild)
-
-	v = last_iter
-
-	# The last index will not roll over so this can be handled easily
-	if dim == ndims(ps)
-		return v
-	end
-
-	if _checkrollover(ps, dim, firstindchild, lastindchild)
-		iter = ps.iterators[dim]
-		v = maximum(iter)
-	end
-
-	return v
+    Base.depwarn("maximum(ps::AbstractConstrainedProduct, dim) is deprecated, use maximum(ps, dim = dim) instead", :maximum)
+    maximum(ps, dim = dim)
 end
 
 function Base.maximum(ps::AbstractConstrainedProduct{<:Any,1})
-	isempty(ps) && return nothing
-	lastindchild = childindex(ps, ps.lastind)
-	lic_dim = lastindchild[1]
-	iter = ps.iterators[1]
-	iter[lic_dim]
+    isempty(ps) && return nothing
+    lastindchild = childindex(ps, ps.lastind)
+    lic_dim = lastindchild[1]
+    iter = ps.iterators[1]
+    iter[lic_dim]
 end
 
 """
-	minimum(ps::AbstractConstrainedProduct; dim::Integer)
-	minimum(ps::AbstractConstrainedProduct, dim::Integer)
+    minimum(ps::AbstractConstrainedProduct; dim::Integer)
 
-Compute the minimum value of the section of the `dim`-th range contained in `ps`.
+Compute the minimum value of the section of the range number `dim` contained in `ps`.
 
 # Examples
 ```jldoctest
@@ -471,50 +476,54 @@ julia> collect(ps)
  (1, 4)
  (2, 4)
 
-julia> minimum(ps, dim=1)
+julia> minimum(ps, dim = 1)
 1
 
-julia> minimum(ps, dim=2)
+julia> minimum(ps, dim = 2)
 4
 ```
 """
+function Base.minimum(ps::AbstractConstrainedProduct; dim::Integer)
+    
+    isempty(ps) && return nothing
+
+    firstindchild = childindex(ps, ps.firstind)
+    lastindchild = childindex(ps, ps.lastind)
+
+    first_iter,last_iter = _firstlastalongdim(ps, dim, firstindchild, lastindchild)
+
+    v = first_iter
+
+    # The last index will not roll over so this can be handled easily
+    if dim == ndims(ps)
+        return v
+    end
+
+    if _checkrollover(ps, dim, firstindchild, lastindchild)
+        iter = ps.iterators[dim]
+        v = minimum(iter)
+    end
+
+    return v
+end
+
 function Base.minimum(ps::AbstractConstrainedProduct, dim::Integer)
-	
-	isempty(ps) && return nothing
-
-	firstindchild = childindex(ps, ps.firstind)
-	lastindchild = childindex(ps, ps.lastind)
-
-	first_iter,last_iter = _firstlastalongdim(ps, dim, firstindchild, lastindchild)
-
-	v = first_iter
-
-	# The last index will not roll over so this can be handled easily
-	if dim == ndims(ps)
-		return v
-	end
-
-	if _checkrollover(ps, dim, firstindchild, lastindchild)
-		iter = ps.iterators[dim]
-		v = minimum(iter)
-	end
-
-	return v
+    Base.depwarn("minimum(ps::AbstractConstrainedProduct, dim) is deprecated, use minimum(ps, dim = dim) instead", :minimum)
+    minimum(ps, dim = dim)
 end
 
 function Base.minimum(ps::AbstractConstrainedProduct{<:Any,1})
-	isempty(ps) && return nothing
-	firstindchild = childindex(ps,ps.firstind)
-	fic_dim = firstindchild[1]
-	iter = ps.iterators[1]
-	iter[fic_dim]
+    isempty(ps) && return nothing
+    firstindchild = childindex(ps,ps.firstind)
+    fic_dim = firstindchild[1]
+    iter = ps.iterators[1]
+    iter[fic_dim]
 end
 
 """
-	extrema(ps::AbstractConstrainedProduct; dim::Integer)
-	extrema(ps::AbstractConstrainedProduct, dim::Integer)
+    extrema(ps::AbstractConstrainedProduct; dim::Integer)
 
-Compute the `extrema` of the section of the `dim`-th range contained in `ps`.
+Compute the `extrema` of the section of the range number `dim` contained in `ps`.
 
 # Examples
 ```jldoctest
@@ -525,57 +534,67 @@ julia> collect(ps)
  (1, 4)
  (2, 4)
 
-julia> extrema(ps, dim=1)
+julia> extrema(ps, dim = 1)
 (1, 2)
 
-julia> extrema(ps, dim=2)
+julia> extrema(ps, dim = 2)
 (4, 4)
 ```
 """
-function Base.extrema(ps::AbstractConstrainedProduct, dim::Integer)
-	
-	isempty(ps) && return nothing
+function Base.extrema(ps::AbstractConstrainedProduct; dim::Integer)
+    
+    isempty(ps) && return nothing
 
-	firstindchild = childindex(ps, ps.firstind)
-	lastindchild = childindex(ps, ps.lastind)
+    firstindchild = childindex(ps, ps.firstind)
+    lastindchild = childindex(ps, ps.lastind)
 
-	first_iter,last_iter = _firstlastalongdim(ps, dim, firstindchild, lastindchild)
+    first_iter,last_iter = _firstlastalongdim(ps, dim, firstindchild, lastindchild)
 
-	v = (first_iter,last_iter)
-	# The last index will not roll over so this can be handled easily
-	if dim == ndims(ps)
-		return v
-	end
+    v = (first_iter,last_iter)
+    # The last index will not roll over so this can be handled easily
+    if dim == ndims(ps)
+        return v
+    end
 
-	if _checkrollover(ps, dim, firstindchild, lastindchild)
-		iter = ps.iterators[dim]
-		v = extrema(iter)
-	end
+    if _checkrollover(ps, dim, firstindchild, lastindchild)
+        iter = ps.iterators[dim]
+        v = extrema(iter)
+    end
 
-	return v
+    return v
 end
 
 function Base.extrema(ps::AbstractConstrainedProduct{<:Any,1})
-	isempty(ps) && return nothing
-	firstindchild = childindex(ps, ps.firstind)
-	lastindchild = childindex(ps, ps.lastind)
-	fic_dim = firstindchild[1]
-	lic_dim = lastindchild[1]
-	iter = ps.iterators[1]
-	
-	(iter[fic_dim], iter[lic_dim])
+    isempty(ps) && return nothing
+    firstindchild = childindex(ps, ps.firstind)
+    lastindchild = childindex(ps, ps.lastind)
+    fic_dim = firstindchild[1]
+    lic_dim = lastindchild[1]
+    iter = ps.iterators[1]
+    
+    (iter[fic_dim], iter[lic_dim])
 end
 
-for f in [:maximum, :minimum, :extrema]
-	@eval function Base.$f(ps::AbstractConstrainedProduct; dim::Integer)
-		$f(ps, dim)
-	end
+function Base.extrema(ps::AbstractConstrainedProduct, dim::Integer)
+    Base.depwarn("extrema(ps::AbstractConstrainedProduct, dim) is deprecated, use extrema(ps, dim = dim) instead", :extrema)
+    extrema(ps, dim = dim)
 end
 
 """
-	extremadims(ps::AbstractConstrainedProduct)
+    extremadims(ps::AbstractConstrainedProduct)
 
-Compute the extrema of the sections of all the ranges contained in `ps`.
+Compute the extrema of the sections of all the ranges contained in `ps`. 
+Functionally this is equivalent to 
+
+```julia
+map(i -> extrema(ps, dim = i), 1:ndims(ps))
+```
+
+but it is implemented more efficiently. 
+
+Returns a `Tuple` containing the `(min, max)` pairs along each 
+dimension, such that the `i`-th index of the result contains the `extrema` along the section of the `i`-th range
+contained locally.
 
 # Examples
 ```jldoctest
@@ -590,15 +609,18 @@ julia> extremadims(ps)
 ((1, 2), (4, 4))
 ```
 """
-extremadims(ps::AbstractConstrainedProduct) = _extremadims(ps, 1, ps.iterators)
+function extremadims(ps::AbstractConstrainedProduct)
+    Base.depwarn("extremadims will not be exported in a future release, please call it as ParallelUtilities.extremadims instead", :extremadims)
+    _extremadims(ps, 1, ps.iterators)
+end
 
 function _extremadims(ps::AbstractConstrainedProduct, dim::Integer, iterators::Tuple)
-	(extrema(ps; dim=dim), _extremadims(ps, dim+1, Base.tail(iterators))...)
+    (extrema(ps; dim = dim), _extremadims(ps, dim+1, Base.tail(iterators))...)
 end
 _extremadims(::AbstractConstrainedProduct, ::Integer, ::Tuple{}) = ()
 
 """
-	extrema_commonlastdim(ps::AbstractConstrainedProduct)
+    extrema_commonlastdim(ps::AbstractConstrainedProduct)
 
 Return the reverse-lexicographic extrema of values taken from 
 ranges contained in `ps`, where the pairs of ranges are constructed 
@@ -627,47 +649,49 @@ julia> extrema_commonlastdim(ps)
 """
 function extrema_commonlastdim(ps::AbstractConstrainedProduct{<:Any,N}) where {N}
 
-	isempty(ps) && return nothing
-	
-	m = extremadims(ps)
-	lastvar_min = last(m)[1]
-	lastvar_max = last(m)[2]
+    Base.depwarn("extrema_commonlastdim will not be exported in a future release, please call it as ParallelUtilities.extrema_commonlastdim instead", :extrema_commonlastdim)
 
-	val_first = first(ps)
-	val_last = last(ps)
-	min_vals = collect(val_first[1:end-1])
-	max_vals = collect(val_last[1:end-1])
+    isempty(ps) && return nothing
+    
+    m = extremadims(ps)
+    lastvar_min = last(m)[1]
+    lastvar_max = last(m)[2]
 
-	for val in ps
-		val_rev = reverse(val)
-		lastvar = first(val_rev)
-		(lastvar_min < lastvar < lastvar_max) && continue
+    val_first = first(ps)
+    val_last = last(ps)
+    min_vals = collect(val_first[1:end-1])
+    max_vals = collect(val_last[1:end-1])
 
-		for (ind,vi) in enumerate(Base.tail(val_rev))
-			if lastvar==lastvar_min
-				min_vals[N-ind] = min(min_vals[N-ind],vi)
-			end
-			if lastvar==lastvar_max
-				max_vals[N-ind] = max(max_vals[N-ind],vi)
-			end
-		end
-	end
+    for val in ps
+        val_rev = reverse(val)
+        lastvar = first(val_rev)
+        (lastvar_min < lastvar < lastvar_max) && continue
 
-	[(m,lastvar_min) for m in min_vals],[(m,lastvar_max) for m in max_vals]
+        for (ind,vi) in enumerate(Base.tail(val_rev))
+            if lastvar==lastvar_min
+                min_vals[N-ind] = min(min_vals[N-ind],vi)
+            end
+            if lastvar==lastvar_max
+                max_vals[N-ind] = max(max_vals[N-ind],vi)
+            end
+        end
+    end
+
+    [(m,lastvar_min) for m in min_vals],[(m,lastvar_max) for m in max_vals]
 end
 
 _infullrange(val::T, ps::AbstractConstrainedProduct{T}) where {T} = _infullrange(val,ps.iterators)
 
 function _infullrange(val, t::Tuple)
-	first(val) in first(t) && _infullrange(Base.tail(val),Base.tail(t))
+    first(val) in first(t) && _infullrange(Base.tail(val),Base.tail(t))
 end
 _infullrange(::Tuple{}, ::Tuple{}) = true
 
 function c2l_rec(iprev, nprev, ax, inds)
-	i = searchsortedfirst(ax[1],inds[1])
-	inew = iprev + (i-1)*nprev
-	n = nprev*length(ax[1])
-	c2l_rec(inew, n, Base.tail(ax), Base.tail(inds))
+    i = searchsortedfirst(ax[1],inds[1])
+    inew = iprev + (i-1)*nprev
+    n = nprev*length(ax[1])
+    c2l_rec(inew, n, Base.tail(ax), Base.tail(inds))
 end
 
 c2l_rec(i, n, ::Tuple{}, ::Tuple{}) = i
@@ -675,7 +699,7 @@ c2l_rec(i, n, ::Tuple{}, ::Tuple{}) = i
 _cartesiantolinear(ax, inds) = c2l_rec(1,1,ax,inds)
 
 """
-	ParallelUtilities.indexinproduct(iterators::Tuple{Vararg{AbstractRange,N}}, val::Tuple{Any,N}) where {N}
+    ParallelUtilities.indexinproduct(iterators::NTuple{N,AbstractRange}, val::NTuple{N,Any}) where {N}
 
 Return the index of `val` in the outer product of `iterators`, 
 where `iterators` is a `Tuple` of increasing `AbstractRange`s. 
@@ -695,35 +719,35 @@ true
 ```
 """
 function indexinproduct(iterators::Tuple{Vararg{AbstractRange,N}},
-	val::Tuple{Vararg{Any,N}}) where {N}
+    val::Tuple{Vararg{Any,N}}) where {N}
 
-	all(in.(val,iterators)) || return nothing
+    all(in.(val,iterators)) || return nothing
 
-	ax = axes.(iterators,1)
-	individual_inds = searchsortedfirst.(iterators,val)
+    ax = axes.(iterators,1)
+    individual_inds = searchsortedfirst.(iterators,val)
 
-	_cartesiantolinear(ax, individual_inds)
+    _cartesiantolinear(ax, individual_inds)
 end
 
 indexinproduct(::Tuple{}, ::Tuple) = throw(ArgumentError("need at least one iterator"))
 
 function Base.in(val::T, ps::AbstractConstrainedProduct{T}) where {T}
-	_infullrange(val,ps) || return false
-	
-	ind = indexinproduct(ps.iterators, val)
-	ps.firstind <= ind <= ps.lastind
+    _infullrange(val,ps) || return false
+    
+    ind = indexinproduct(ps.iterators, val)
+    ps.firstind <= ind <= ps.lastind
 end
 
 # This struct is just a wrapper to flip the tuples before comparing
 struct ReverseLexicographicTuple{T}
-	t :: T
+    t :: T
 end
 
 Base.isless(a::ReverseLexicographicTuple{T}, b::ReverseLexicographicTuple{T}) where {T} = reverse(a.t) < reverse(b.t)
 Base.isequal(a::ReverseLexicographicTuple{T}, b::ReverseLexicographicTuple{T}) where {T} = a.t == b.t
 
 """
-	whichproc(iterators::Tuple, val::Tuple, np::Integer )
+    whichproc(iterators::Tuple, val::Tuple, np::Integer )
 
 Return the processor rank that will contain `val` if the outer 
 product of the ranges contained in `iterators` is split evenly 
@@ -747,31 +771,31 @@ julia> whichproc(iters, (2,3), np)
 ``` 
 """
 function whichproc(iterators, val, np::Integer)
-	
-	_infullrange(val,iterators) || return nothing
+    
+    _infullrange(val,iterators) || return nothing
 
-	# We may carry out a binary search as the iterators are sorted
-	left,right = 1,np
+    # We may carry out a binary search as the iterators are sorted
+    left,right = 1,np
 
-	val_t = ReverseLexicographicTuple(val)
+    val_t = ReverseLexicographicTuple(val)
 
-	while left <= right
-		mid = div(left+right, 2)
-		ps = ProductSplit(iterators, np, mid)
+    while left <= right
+        mid = div(left+right, 2)
+        ps = ProductSplit(iterators, np, mid)
 
-		# If np is greater than the number of ntasks then it's possible
-		# that ps is empty. In this case the value must be somewhere in
-		# the previous workers. Otherwise each worker has some tasks and 
-		# these are sorted, so carry out a binary search
+        # If np is greater than the number of ntasks then it's possible
+        # that ps is empty. In this case the value must be somewhere in
+        # the previous workers. Otherwise each worker has some tasks and 
+        # these are sorted, so carry out a binary search
 
-		if isempty(ps) || val_t < ReverseLexicographicTuple(first(ps))
-			right = mid - 1
-		elseif val_t > ReverseLexicographicTuple(last(ps))
-			left = mid + 1
-		else
-			return mid
-		end
-	end
+        if isempty(ps) || val_t < ReverseLexicographicTuple(first(ps))
+            right = mid - 1
+        elseif val_t > ReverseLexicographicTuple(last(ps))
+            left = mid + 1
+        else
+            return mid
+        end
+    end
 end
 
 whichproc(iterators, ::Nothing, np::Integer) = nothing
@@ -781,7 +805,7 @@ whichproc(iterators, ::Nothing, np::Integer) = nothing
 # The total list of tasks is contained in iterators, and might differ from 
 # ps.iterators (eg if ps contains a subsection of the parameter set)
 """
-	procrange_recast(iterators::Tuple, ps::ProductSplit, np_new::Integer)
+    procrange_recast(iterators::Tuple, ps::ProductSplit, np_new::Integer)
 
 Return the range of processor ranks that would contain the values in `ps` if 
 the outer produce of the ranges in `iterators` is split across `np_new` 
@@ -801,33 +825,52 @@ julia> procrange_recast(iters, ps, 10)
 ```
 """
 function procrange_recast(iterators::Tuple, ps::AbstractConstrainedProduct, np_new::Integer)
-	
-	if isempty(ps)
-		return 0:-1 # empty range
-	end
+    
+    Base.depwarn("procrange_recast will not be exported in a future release, please call it as ParallelUtilities.procrange_recast instead", :procrange_recast)
 
-	procid_start = whichproc(iterators,first(ps),np_new)
-	if procid_start === nothing
-		throw(TaskNotPresentError(iterators,first(ps)))
-	end
-	if length(ps) == 1
-		procid_end = procid_start
-	else
-		procid_end = whichproc(iterators,last(ps),np_new)
-		if procid_end === nothing
-			throw(TaskNotPresentError(iterators,last(ps)))
-		end
-	end
-	
-	return procid_start:procid_end
-end
+    if isempty(ps)
+        return 0:-1 # empty range
+    end
 
-function procrange_recast(ps::AbstractConstrainedProduct, np_new::Integer)
-	procrange_recast(ps.iterators,ps,np_new)
+    procid_start = whichproc(iterators,first(ps),np_new)
+    if procid_start === nothing
+        throw(TaskNotPresentError(iterators,first(ps)))
+    end
+    if length(ps) == 1
+        procid_end = procid_start
+    else
+        procid_end = whichproc(iterators,last(ps),np_new)
+        if procid_end === nothing
+            throw(TaskNotPresentError(iterators,last(ps)))
+        end
+    end
+    
+    return procid_start:procid_end
 end
 
 """
-	localindex(ps::ProductSplit{T}, val::T) where {T}
+    procrange_recast(ps::AbstractConstrainedProduct, np_new::Integer)
+
+Return the range of processor ranks that would contain the values in `ps` if the 
+iterators used to construct `ps` were split across `np_new` processes.
+
+# Examples
+```jldoctest
+julia> iters = (1:10, 4:6, 1:4);
+
+julia> ps = ProductSplit(iters, 5, 2); # split across 5 processes initially
+
+# If `iters` were spread across 10 processes, the tasks in `ps` would be spread across 
+julia> procrange_recast(ps, 10)
+3:4
+```
+"""
+function procrange_recast(ps::AbstractConstrainedProduct, np_new::Integer)
+    procrange_recast(ps.iterators, ps, np_new)
+end
+
+"""
+    localindex(ps::ProductSplit{T}, val::T) where {T}
 
 Return the index of `val` in `ps`. Return `nothing` if the value
 is not found.
@@ -849,21 +892,21 @@ julia> localindex(ps, (3,9))
 """
 function localindex(ps::AbstractConstrainedProduct{T}, val::T) where {T}
 
-	(isempty(ps) || val ∉ ps) && return nothing
+    (isempty(ps) || val ∉ ps) && return nothing
 
-	indflat = indexinproduct(ps.iterators, val)
-	indflat - ps.firstind + 1
+    indflat = indexinproduct(ps.iterators, val)
+    indflat - ps.firstind + 1
 end
 
 localindex(::AbstractConstrainedProduct, ::Nothing) = nothing
 
 function localindex(iterators::Tuple, val::Tuple, np::Integer, p::Integer)
-	ps = ProductSplit(iterators, np, p)
-	localindex(ps, val)
+    ps = ProductSplit(iterators, np, p)
+    localindex(ps, val)
 end
 
 """
-	whichproc_localindex(iterators::Tuple, val::Tuple, np::Integer)
+    whichproc_localindex(iterators::Tuple, val::Tuple, np::Integer)
 
 Return `(rank,ind)`, where `rank` is the
 rank of the worker that `val` will reside on if the outer product 
@@ -887,15 +930,15 @@ julia> ProductSplit(iters, np, 4) |> collect
 ```
 """
 function whichproc_localindex(iterators::Tuple, val::Tuple, np::Integer)
-	procid = whichproc(iterators,val,np)
-	index = localindex(iterators,val,np,procid)
-	return procid,index
+    procid = whichproc(iterators, val, np)
+    index = localindex(iterators, val, np, procid)
+    return procid, index
 end
 
 #################################################################
 
 """
-	ParallelUtilities.dropleading(ps::AbstractConstrainedProduct)
+    ParallelUtilities.dropleading(ps::AbstractConstrainedProduct)
 
 Return a `ProductSection` leaving out the first iterator contained in `ps`. 
 The range of values of the remaining iterators in the 
@@ -923,11 +966,11 @@ julia> ParallelUtilities.dropleading(ps) |> collect
 ```
 """
 function dropleading(ps::AbstractConstrainedProduct)
-	isempty(ps) && throw(ArgumentError("need at least one iterator"))
-	iterators = Base.tail(ps.iterators)
-	first_element = Base.tail(first(ps))
-	last_element = Base.tail(last(ps))
-	firstind = indexinproduct(iterators, first_element)
-	lastind = indexinproduct(iterators, last_element)
-	ProductSection(iterators,firstind:lastind)
+    isempty(ps) && throw(ArgumentError("need at least one iterator"))
+    iterators = Base.tail(ps.iterators)
+    first_element = Base.tail(first(ps))
+    last_element = Base.tail(last(ps))
+    firstind = indexinproduct(iterators, first_element)
+    lastind = indexinproduct(iterators, last_element)
+    ProductSection(iterators,firstind:lastind)
 end

--- a/src/productsplit.jl
+++ b/src/productsplit.jl
@@ -205,7 +205,7 @@ Base.firstindex(ps::AbstractConstrainedProduct) = 1
 Base.lastindex(ps::AbstractConstrainedProduct) = ps.lastind - ps.firstind + 1
 
 """
-    ParallelUtilities.childindex(ps::AbstractConstrainedProduct, ind)
+    childindex(ps::AbstractConstrainedProduct, ind)
 
 Return a tuple containing the indices of the individual iterators 
 corresponding to the element that is present at index `ind` in the 
@@ -241,7 +241,7 @@ end
 childindex(::Tuple{}, ind) = (ind,)
 
 """
-    ParallelUtilities.childindexshifted(ps::AbstractConstrainedProduct, ind)
+    childindexshifted(ps::AbstractConstrainedProduct, ind)
 
 Return a tuple containing the indices in the individual iterators 
 given an index of a `AbstractConstrainedProduct`.
@@ -345,8 +345,7 @@ function _nrollovers(ps::AbstractConstrainedProduct, dim::Integer)
 end
 
 """
-    ParallelUtilities.nelements(ps::AbstractConstrainedProduct; dim::Integer)
-    ParallelUtilities.nelements(ps::AbstractConstrainedProduct, dim::Integer)
+    nelements(ps::AbstractConstrainedProduct; dim::Integer)
 
 Compute the number of unique values in the section of the `dim`-th range contained in `ps`.
 
@@ -364,18 +363,21 @@ julia> collect(ps)
  (5, 2, 2)
  (1, 3, 2)
 
-julia> ParallelUtilities.nelements(ps, 1)
+julia> ParallelUtilities.nelements(ps, dim = 1)
 5
 
-julia> ParallelUtilities.nelements(ps, 2)
+julia> ParallelUtilities.nelements(ps, dim = 2)
 3
 
-julia> ParallelUtilities.nelements(ps, 3)
+julia> ParallelUtilities.nelements(ps, dim = 3)
 2
 ```
 """
-nelements(ps::AbstractConstrainedProduct; dim::Integer) = nelements(ps,dim)
 function nelements(ps::AbstractConstrainedProduct, dim::Integer)
+    Base.depwarn("nelements(ps, dim) is deprecated, please use nelements(ps, dim = dim)", :nelements)
+    nelements(ps, dim = dim)
+end
+function nelements(ps::AbstractConstrainedProduct; dim::Integer)
     1 <= dim <= ndims(ps) || throw(ArgumentError("1 ⩽ dim ⩽ N=$(ndims(ps)) not satisfied for dim=$dim"))
 
     iter = ps.iterators[dim]
@@ -699,7 +701,7 @@ c2l_rec(i, n, ::Tuple{}, ::Tuple{}) = i
 _cartesiantolinear(ax, inds) = c2l_rec(1,1,ax,inds)
 
 """
-    ParallelUtilities.indexinproduct(iterators::NTuple{N,AbstractRange}, val::NTuple{N,Any}) where {N}
+    indexinproduct(iterators::NTuple{N,AbstractRange}, val::NTuple{N,Any}) where {N}
 
 Return the index of `val` in the outer product of `iterators`, 
 where `iterators` is a `Tuple` of increasing `AbstractRange`s. 
@@ -747,7 +749,7 @@ Base.isless(a::ReverseLexicographicTuple{T}, b::ReverseLexicographicTuple{T}) wh
 Base.isequal(a::ReverseLexicographicTuple{T}, b::ReverseLexicographicTuple{T}) where {T} = a.t == b.t
 
 """
-    whichproc(iterators::Tuple, val::Tuple, np::Integer )
+    whichproc(iterators::Tuple, val::Tuple, np::Integer)
 
 Return the processor rank that will contain `val` if the outer 
 product of the ranges contained in `iterators` is split evenly 
@@ -860,8 +862,7 @@ julia> iters = (1:10, 4:6, 1:4);
 
 julia> ps = ProductSplit(iters, 5, 2); # split across 5 processes initially
 
-# If `iters` were spread across 10 processes, the tasks in `ps` would be spread across 
-julia> procrange_recast(ps, 10)
+julia> procrange_recast(ps, 10) # If `iters` were spread across 10 processes
 3:4
 ```
 """
@@ -938,7 +939,7 @@ end
 #################################################################
 
 """
-    ParallelUtilities.dropleading(ps::AbstractConstrainedProduct)
+    dropleading(ps::AbstractConstrainedProduct)
 
 Return a `ProductSection` leaving out the first iterator contained in `ps`. 
 The range of values of the remaining iterators in the 

--- a/src/reductionfunctions.jl
+++ b/src/reductionfunctions.jl
@@ -29,11 +29,11 @@ function checkdims(A, d::Integer)
 end
 
 """
-	ParallelUtilities.sumcat_aligned(A::AbstractArray{T,N}...; dims) where {T,N}
+	sumcat_aligned(A::AbstractArray{T,N}...; dims) where {T,N}
 
 Concatenate the arrays along the dimensions `dims` according to their axes, 
 with overlapping sections being summed over. Returns an `OffsetArray` with the minimal 
-axes span encompassing all the arrays.
+axis span encompassing all the arrays.
 
 `dims` may be an `Integer` or a collection of `Integer`s, but all elements of `dims` must be from the range `1:N`.
 
@@ -90,11 +90,11 @@ end
 sumcat_aligned(A1::AbstractArray; dims) = (all(x -> 1 <= x <= ndims(A1), dims) || throw_dimserror(dims); A1)
 
 """
-	ParallelUtilities.sumvcat_aligned(A::AbstractArray{T,N}...) where {T,N}
+	sumvcat_aligned(A::AbstractArray{T,N}...) where {T,N}
 
 Concatenate the arrays along the first dimension according to their axes, 
 with overlapping sections being summed over. Returns an `OffsetArray` with the minimal 
-axes span encompassing all the arrays.
+axis span encompassing all the arrays.
 
 The input arrays must be at least one-dimensional.
 
@@ -147,11 +147,11 @@ function sumvcat_aligned(A::AbstractArray)
 end
 
 """
-	ParallelUtilities.sumhcat_aligned(A::AbstractArray{T,N}...) where {T,N}
+	sumhcat_aligned(A::AbstractArray{T,N}...) where {T,N}
 
 Concatenate the arrays along the second dimension according to their axes, 
 with overlapping sections being summed over. Returns an `OffsetArray` with the minimal 
-axes span encompassing all the arrays. 
+axis span encompassing all the arrays. 
 
 The input arrays must be at least two-dimensional.
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,96 +1,21 @@
 """
-	nworkersactive(iterators::Tuple)
+    nworkersactive(iterators::Tuple)
 
 Number of workers required to contain the outer product of the iterators.
 """
-@inline function nworkersactive(iterators::Tuple)
-	min(nworkers(), ntasks(iterators))
+function nworkersactive(iterators::Tuple)
+    min(nworkers(), prod(length, iterators))
 end
-@inline nworkersactive(ps::ProductSplit) = nworkersactive(ps.iterators)
-@inline nworkersactive(args::AbstractRange...) = nworkersactive(args)
+nworkersactive(ps::ProductSplit) = nworkersactive(ps.iterators)
+nworkersactive(args::AbstractRange...) = nworkersactive(args)
 
 """
-	workersactive(iterators::Tuple)
+    workersactive(iterators::Tuple)
 
 Workers required to split the outer product of the iterators. 
-If `ntasks(iterators) < nworkers()` then the first `ntasks(iterators)`
+If `prod(length, iterators) < nworkers()` then the first `prod(length, iterators)`
 workers are chosen.
 """
-@inline workersactive(iterators::Tuple) = workers()[1:nworkersactive(iterators)]
-@inline workersactive(ps::ProductSplit) = workersactive(ps.iterators)
-@inline workersactive(args::AbstractRange...) = workersactive(args)
-
-"""
-	gethostnames(procs = workers())
-
-Return the hostname of each worker in `procs`. This is obtained by evaluating 
-`Libc.gethostname()` on each worker asynchronously.
-"""
-function gethostnames(procs = workers())
-	hostnames = Vector{String}(undef, length(procs))
-	@sync for (ind,p) in enumerate(procs)
-		@async hostnames[ind] = @fetchfrom p Libc.gethostname()
-	end
-	return hostnames
-end
-
-"""
-	nodenames(procs = workers())
-
-Return the unique hostnames that the workers in `procs` lie on. 
-On an HPC system these are usually the hostnames of the nodes involved.
-"""
-nodenames(procs = workers()) = nodenames(gethostnames(procs))
-function nodenames(hostnames::Vector{String})
-	nodes = unique(hostnames)
-end
-
-"""
-	procs_node(procs = workers())
-
-Return the worker ids on each host of the cluster.
-On an HPC system this would return the workers on each node.
-"""
-function procs_node(procs = workers())
-	hosts = gethostnames(procs)
-	nodes = nodenames(hosts)
-	procs_node(procs,hosts,nodes)
-end
-
-function procs_node(procs,hosts,nodes)
-	d = OrderedDict{String,Vector{Int}}()
-	for node in nodes
-		p = procs[findall(isequal(node),hosts)]
-		d[node] = p
-	end
-	return d
-end
-
-"""
-	nprocs_node(procs = workers())
-
-Return the number of workers on each host.
-On an HPC system this would return the number of workers on each node.
-"""
-function nprocs_node(procs = workers())
-	nprocs_node(gethostnames(procs))
-end
-
-function nprocs_node(hostnames::Vector{String})
-	nodes = nodenames(hostnames)
-	nprocs_node(hostnames,nodes)	
-end
-
-function nprocs_node(hostnames::Vector{String},nodes::Vector{String})
-	Dict(node=>count(isequal(node),hostnames) for node in nodes)
-end
-
-function nprocs_node(d::AbstractDict{String,<:AbstractVector{<:Integer}})
-	nphost = OrderedDict{String,Int}()
-	for (node,pnode) in d
-		nphost[node] = length(pnode)
-	end
-	return nphost
-end
-
-
+workersactive(iterators::Tuple) = workers()[1:nworkersactive(iterators)]
+workersactive(ps::ProductSplit) = workersactive(ps.iterators)
+workersactive(args::AbstractRange...) = workersactive(args)

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -433,31 +433,32 @@ end
     end
     @testset "nelements" begin
         ps = ProductSplit((1:5,2:4,1:3),7,3);
-        @test nelements(ps,dim=1) == 5
-        @test nelements(ps,dim=2) == 3
-        @test nelements(ps,dim=3) == 2
-        @test_throws ArgumentError nelements(ps,dim=0)
-        @test_throws ArgumentError nelements(ps,dim=4)
+        @test nelements(ps, dim = 1) == 5
+        @test nelements(ps, dim = 2) == 3
+        @test nelements(ps, dim = 3) == 2
+        @test_throws ArgumentError nelements(ps, dim = 0)
+        @test_throws ArgumentError nelements(ps, dim = 4)
 
         ps = ProductSection((1:5,2:4,1:3),5:8);
-        @test nelements(ps,1) == 4
-        @test nelements(ps,2) == 2
-        @test nelements(ps,3) == 1
+        @test (@test_deprecated nelements(ps,1)) == nelements(ps, dim = 1)
+        @test nelements(ps, dim =1) == 4
+        @test nelements(ps, dim =2) == 2
+        @test nelements(ps, dim =3) == 1
 
         ps = ProductSection((1:5,2:4,1:3),5:11);
-        @test nelements(ps,1) == 5
-        @test nelements(ps,2) == 3
-        @test nelements(ps,3) == 1
+        @test nelements(ps, dim = 1) == 5
+        @test nelements(ps, dim = 2) == 3
+        @test nelements(ps, dim = 3) == 1
 
         ps = ProductSection((1:5,2:4,1:3),4:8);
-        @test nelements(ps,1) == 5
-        @test nelements(ps,2) == 2
-        @test nelements(ps,3) == 1
+        @test nelements(ps, dim = 1) == 5
+        @test nelements(ps, dim = 2) == 2
+        @test nelements(ps, dim = 3) == 1
 
         ps = ProductSection((1:5,2:4,1:3),4:9);
-        @test nelements(ps,1) == 5
-        @test nelements(ps,2) == 2
-        @test nelements(ps,3) == 1
+        @test nelements(ps, dim = 1) == 5
+        @test nelements(ps, dim = 2) == 2
+        @test nelements(ps, dim = 3) == 1
     end
     
     @test ParallelUtilities._checknorollover((),(),())

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -2192,16 +2192,16 @@ end
                     @test res == res_exp
                 end
                 @testset "with progress" begin
-                    res = pmapsum(x->x[1][1],Int,1:nworkers(),showprogress=true)
+                    res = @test_deprecated pmapsum(x->x[1][1],Int,1:nworkers(), showprogress=true)
                     @test res == res_exp
-                    res = pmapsum(x->x[1][1],1:nworkers(),showprogress=true)
+                    res = @test_deprecated pmapsum(x->x[1][1],1:nworkers(), showprogress=true)
                     @test res == res_exp
                 end
-			    @test pmapsum(x->x[1][1],Int,(1:nworkers(),)) == res_exp
-                @test pmapsum(x->x[1][1],(1:nworkers(),)) == res_exp
-                @test pmapsum(x->x[1][1],Int,(1:nworkers(),1:1)) == res_exp
-			    @test pmapsum(x->x[1][1],(1:nworkers(),1:1)) == res_exp
-			    @test pmapsum(x->myid(),1:nworkers()) == sum(workers())
+			    @test pmapsum(x->x[1][1], Int, (1:nworkers(),)) == res_exp
+                @test pmapsum(x->x[1][1], (1:nworkers(),)) == res_exp
+                @test pmapsum(x->x[1][1], Int, (1:nworkers(), 1:1)) == res_exp
+			    @test pmapsum(x->x[1][1], (1:nworkers(), 1:1)) == res_exp
+			    @test pmapsum(x->myid(), 1:nworkers()) == sum(workers())
 		    end
 		    
 		    @testset "one iterator" begin
@@ -2263,7 +2263,7 @@ end
                     @test res == sum(iterable)
                 end
                 @testset "with progress" begin
-                    res = pmapsum_elementwise(identity,iterable,showprogress=true)
+                    res = @test_deprecated pmapsum_elementwise(identity,iterable, showprogress=true)
                     @test res == sum(iterable) 
                 end
                 res = pmapsum_elementwise(identity,(iterable,))
@@ -2327,9 +2327,9 @@ end
                     @test res == res_exp
                 end
                 @testset "with progress" begin
-                    res = pmapreduce_commutative(x->myid(),Int,sum,Int,1:nworkers(),showprogress=true)
+                    res = @test_deprecated pmapreduce_commutative(x->myid(),Int,sum,Int,1:nworkers(), showprogress=true)
     			    @test res == res_exp
-                    res = pmapreduce_commutative(x->myid(),sum,1:nworkers(),showprogress=true)
+                    res = @test_deprecated  pmapreduce_commutative(x->myid(),sum,1:nworkers(), showprogress=true)
                     @test res == res_exp
                 end
                 @test pmapreduce_commutative(x->myid(),Int,sum,Int,(1:nworkers(),)) == res_exp
@@ -2402,7 +2402,7 @@ end
                     @test res == res_exp
                 end
                 @testset "with progress" begin
-    			    res = pmapreduce_commutative_elementwise(x->x^2,sum,iter,showprogress=true)
+    			    res = @test_deprecated pmapreduce_commutative_elementwise(x->x^2,sum,iter, showprogress=true)
     			    @test res == res_exp
                 end
 			    @test res == pmapsum_elementwise(x->x^2,iter)
@@ -2464,9 +2464,9 @@ end
                     @test pmapreduce(x->myid(),sum,1:nworkers()) == res_exp
                 end
                 @testset "without progress" begin
-                    res = pmapreduce(x->myid(),Int,sum,Int,1:nworkers(),showprogress=true)
+                    res = @test_deprecated pmapreduce(x->myid(),Int,sum,Int,1:nworkers(), showprogress=true)
                     @test res == res_exp
-                    res = pmapreduce(x->myid(),sum,1:nworkers(),showprogress=true)
+                    res = @test_deprecated pmapreduce(x->myid(),sum,1:nworkers(), showprogress=true)
                     @test res == res_exp
                 end
 			    @test pmapreduce(x->myid(),Int,sum,Int,(1:nworkers(),)) == res_exp

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -13,6 +13,8 @@
     nelements
 end
 
+const future_release_warn = r"will not be exported in a future release"i
+
 @test isempty(Test.detect_ambiguities(Base, Core, ParallelUtilities))
 
 macro testsetwithinfo(str,ex)
@@ -57,14 +59,14 @@ end
         @testset "Constructor" begin
 
     	    function checkPSconstructor(iters,npmax=10)
-    	    	ntasks_total = prod(length.(iters))
+    	    	ntasks_total = prod(length, iters)
     			for np = 1:npmax, p = 1:np
     		        ps = ProductSplit(iters, np, p)
                     @test eltype(ps) == Tuple{eltype.(iters)...}
                     @test ndims(ps) == length(iters)
     		        @test collect(ps) == collect(split_product_across_processors_iterators(iters,np,p))
-    		        @test ntasks(ps) == ntasks_total
-    		        @test ntasks(ps.iterators) == ntasks_total
+    		        @test (@test_deprecated ntasks(ps)) == ntasks_total
+    		        @test prod(length, ps.iterators) == ntasks_total
                     @test ParallelUtilities.workerrank(ps) == p
     		    end
 
@@ -118,21 +120,21 @@ end
     	    	    ps = ProductSplit(iters,2,1)
     	    	    @test firstindex(ps) == 1
     	    	    @test ps.firstind == 1
-    	    	    @test ps.lastind == div(ntasks(iters),2)
-    	    	    @test lastindex(ps) == div(ntasks(iters),2)
+    	    	    @test ps.lastind == div(prod(length, iters),2)
+    	    	    @test lastindex(ps) == div(prod(length, iters),2)
     	    	    @test lastindex(ps) == length(ps)
     	    	    ps = ProductSplit(iters,2,2)
-    	    	    @test ps.firstind == div(ntasks(iters),2) + 1
+    	    	    @test ps.firstind == div(prod(length, iters),2) + 1
     	    	    @test firstindex(ps) == 1
-    	    	    @test ps.lastind == ntasks(iters)
+    	    	    @test ps.lastind == prod(length, iters)
     	    	    @test lastindex(ps) == length(ps)
 
-    	    	    for np in ntasks(iters)+1:ntasks(iters)+10,
-    	    	    	p in ntasks(iters)+1:np
+    	    	    for np in prod(length, iters)+1:prod(length, iters)+10,
+    	    	    	p in prod(length, iters)+1:np
 
     		    	    ps = ProductSplit(iters,np,p)
-    		    	    @test ps.firstind == ntasks(iters) + 1
-    		    	    @test ps.lastind == ntasks(iters)
+    		    	    @test ps.firstind == prod(length, iters) + 1
+    		    	    @test ps.lastind == prod(length, iters)
     		    	end
     		    end
         	end
@@ -160,21 +162,21 @@ end
 
             	@test ParallelUtilities._first(()) == ()
 
-                for iters in various_iters,np=1:5ntasks(iters)
+                for iters in various_iters,np=1:5prod(length, iters)
 
     	            ps = ProductSplit(iters,np,1)
     	            @test first(ps) == ( isempty(ps) ? nothing : map(first,iters) )
     	        end
 
     	        iters = (1:1,)
-    	        ps = ProductSplit(iters,2ntasks(iters),ntasks(iters)+1) # must be empty
+    	        ps = ProductSplit(iters,2prod(length, iters),prod(length, iters)+1) # must be empty
     	        @test first(ps) === nothing
             end
             @testset "last" begin
 
             	@test ParallelUtilities._last(()) == ()
 
-                for iters in various_iters,np=1:5ntasks(iters)
+                for iters in various_iters,np=1:5prod(length, iters)
 
     	            ps = ProductSplit(iters,np,np)
     	            @test last(ps) == ( isempty(ps) ? nothing : map(last,iters) )
@@ -196,6 +198,7 @@ end
     			        for dim in 1:length(iters)
     			        	@test begin
     			        		res = fn(ps,dim=dim) == fn(x[dim] for x in pcol)
+                                @test (@test_deprecated fn(ps, dim)) == fn(ps, dim=dim)
     			        		if !res
     			        			println(summary(ps))
     			        		end
@@ -224,13 +227,13 @@ end
         		for iters in various_iters
 
         			dims = length(iters)
-    	    		for np = 1:5ntasks(iters), proc_id = 1:np
+    	    		for np = 1:5prod(length, iters), proc_id = 1:np
     	    	    	ps = ProductSplit(iters,np,proc_id)
     	    	    	if isempty(ps)
-    	    	    		@test extremadims(ps) == Tuple(nothing for i=1:dims)
+    	    	    		@test (@test_deprecated future_release_warn extremadims(ps)) == Tuple(nothing for i=1:dims)
     	    	    	else
     		    	    	ext = Tuple(map(extrema,zip(collect(ps)...)))
-    		    	    	@test extremadims(ps) == ext
+    		    	    	@test (@test_deprecated future_release_warn extremadims(ps)) == ext
     		    	    end
     	    	    end
     	    	end
@@ -239,9 +242,9 @@ end
         	@testset "extrema_commonlastdim" begin
         	    iters = (1:10,4:6,1:4)
         	    ps = ProductSplit(iters,37,8)
-        	    @test extrema_commonlastdim(ps) == ([(9,1),(6,1)],[(2,2),(4,2)])
-        	    ps = ProductSplit(iters,ntasks(iters)+1,ntasks(iters)+1)
-        	    @test extrema_commonlastdim(ps) === nothing
+        	    @test (@test_deprecated future_release_warn extrema_commonlastdim(ps)) == ([(9,1),(6,1)],[(2,2),(4,2)])
+        	    ps = ProductSplit(iters,prod(length, iters)+1,prod(length, iters)+1)
+        	    @test (@test_deprecated future_release_warn extrema_commonlastdim(ps)) === nothing
         	end
         end
 
@@ -278,35 +281,35 @@ end
             ps = ProductSplit(iters,np,proc_id)
             @test whichproc(iters,first(ps),1) == 1
             @test whichproc(iters,(100,100,100),1) === nothing
-            @test procrange_recast(iters,ps,1) == 1:1
-            @test procrange_recast(ps,1) == 1:1
+            @test (@test_deprecated future_release_warn procrange_recast(iters,ps,1)) == 1:1
+            @test (@test_deprecated future_release_warn procrange_recast(ps,1)) == 1:1
 
             smalleriter = (1:1,1:1,1:1)
             err = ParallelUtilities.TaskNotPresentError(smalleriter,first(ps))
-            @test_throws err procrange_recast(smalleriter,ps,1)
+            @test_deprecated future_release_warn @test_throws err procrange_recast(smalleriter,ps,1)
             smalleriter = (7:9,4:6,1:4)
             err = ParallelUtilities.TaskNotPresentError(smalleriter,last(ps))
-            @test_throws err procrange_recast(smalleriter,ps,1)
+            @test_deprecated future_release_warn @test_throws err procrange_recast(smalleriter,ps,1)
 
             iters = (1:1,2:2)
             ps = ProductSplit(iters,np,proc_id)
             @test whichproc(iters,first(ps),np) === nothing
             @test whichproc(iters,nothing,np) === nothing
-            @test procrange_recast(iters,ps,2) == (0:-1)
-            @test procrange_recast(ps,2) == (0:-1)
+            @test (@test_deprecated future_release_warn procrange_recast(iters,ps,2)) == (0:-1)
+            @test (@test_deprecated future_release_warn procrange_recast(ps,2)) == (0:-1)
 
             iters = (1:1,2:2)
             ps = ProductSplit(iters,1,1)
-            @test procrange_recast(iters,ps,2) == 1:1
-            @test procrange_recast(ps,2) == 1:1
+            @test (@test_deprecated future_release_warn procrange_recast(iters,ps,2)) == 1:1
+            @test (@test_deprecated future_release_warn procrange_recast(ps,2)) == 1:1
 
             iters = (Base.OneTo(2),2:4)
             ps = ProductSplit(iters,2,1)
-            @test procrange_recast(iters,ps,1) == 1:1
-            @test procrange_recast(iters,ps,2) == 1:1
-            @test procrange_recast(iters,ps,ntasks(iters)) == 1:length(ps)
+            @test (@test_deprecated future_release_warn procrange_recast(iters,ps,1)) == 1:1
+            @test (@test_deprecated future_release_warn procrange_recast(iters,ps,2)) == 1:1
+            @test (@test_deprecated future_release_warn procrange_recast(iters,ps, prod(length, iters))) == 1:length(ps)
 
-            for np_new in 1:5ntasks(iters)
+            for np_new in 1:5prod(length, iters)
             	for proc_id_new=1:np_new
     	        	ps_new = ProductSplit(iters,np_new,proc_id_new)
 
@@ -317,22 +320,22 @@ end
     	        end
     	        procid_new_first = whichproc(iters,first(ps),np_new)
     	        proc_new_last = whichproc(iters,last(ps),np_new)
-            	@test procrange_recast(iters,ps,np_new) == (isempty(ps) ? (0:-1) : (procid_new_first:proc_new_last))
-            	@test procrange_recast(ps,np_new) == (isempty(ps) ? (0:-1) : (procid_new_first:proc_new_last))
+            	@test (@test_deprecated future_release_warn procrange_recast(iters,ps,np_new)) == (isempty(ps) ? (0:-1) : (procid_new_first:proc_new_last))
+            	@test (@test_deprecated future_release_warn procrange_recast(ps,np_new)) == (isempty(ps) ? (0:-1) : (procid_new_first:proc_new_last))
             end
 
             @testset "different set" begin
     	        iters = (1:100,1:4000)
     	        ps = ProductSplit((20:30,1:1),2,1)
-    	        @test procrange_recast(iters,ps,700) == 1:1
+    	        @test (@test_deprecated future_release_warn procrange_recast(iters,ps,700)) == 1:1
     	        ps = ProductSplit((20:30,1:1),2,2)
-    	        @test procrange_recast(iters,ps,700) == 1:1
+    	        @test (@test_deprecated future_release_warn procrange_recast(iters,ps,700)) == 1:1
 
     	        iters = (1:1,2:2)
     	        ps = ProductSplit((20:30,2:2),2,1)
-    	        @test_throws ParallelUtilities.TaskNotPresentError procrange_recast(iters,ps,3)
+    	        @test_deprecated future_release_warn @test_throws ParallelUtilities.TaskNotPresentError procrange_recast(iters,ps,3)
     	        ps = ProductSplit((1:30,2:2),2,1)
-    	        @test_throws ParallelUtilities.TaskNotPresentError procrange_recast(iters,ps,3)
+    	        @test_deprecated future_release_warn @test_throws ParallelUtilities.TaskNotPresentError procrange_recast(iters,ps,3)
             end
         end
 
@@ -345,7 +348,7 @@ end
         @testset "localindex" begin
             
             for iters in various_iters
-    	        for np=1:5ntasks(iters),proc_id=1:np
+    	        for np=1:5prod(length, iters),proc_id=1:np
     	        	ps = ProductSplit(iters,np,proc_id)
     	        	for (ind,val) in enumerate(ps)
     	        		@test localindex(ps,val) == ind
@@ -360,7 +363,7 @@ end
 
         @testset "whichproc_localindex" begin
             for iters in various_iters
-    	        for np=1:ntasks(iters),proc_id=1:np
+    	        for np=1:prod(length, iters),proc_id=1:np
     	        	ps_col = collect(ProductSplit(iters,np,proc_id))
     	        	ps_col_rev = [reverse(t) for t in ps_col] 
     	        	for val in ps_col
@@ -381,7 +384,7 @@ end
         	@test ParallelUtilities.childindex((),1) == (1,)
 
             for iters in various_iters
-                for np=1:ntasks(iters),p=1:np
+                for np=1:prod(length, iters),p=1:np
                 	ps = ProductSplit(iters,np,p)
                 	ps_col = collect(ps)
                 	for i in 1:length(ps)
@@ -517,27 +520,28 @@ end;
     end
 
     @testset "hostnames" begin
-    	hostnames = gethostnames()
-    	nodes = unique(hostnames)
-        @test hostnames == [@fetchfrom p Libc.gethostname() for p in workers()]
-        @test nodenames() == nodes
-        @test nodenames(hostnames) == nodes
-        np1 = nprocs_node(hostnames,nodes)
-        np2 = nprocs_node(hostnames)
-        np3 = nprocs_node()
+        @test (@test_deprecated gethostnames()) == hostnames()
+    	hosts = hostnames()
+    	nodes = unique(hosts)
+        @test hosts == [@fetchfrom p Libc.gethostname() for p in workers()]
+        @test (@test_deprecated future_release_warn nodenames()) == nodes
+        @test (@test_deprecated future_release_warn nodenames(hosts)) == nodes
+        np1 = @test_deprecated future_release_warn nprocs_node(hosts,nodes)
+        np2 = @test_deprecated future_release_warn nprocs_node(hosts)
+        np3 = @test_deprecated future_release_warn nprocs_node()
         @test np1 == np2 == np3
         for node in nodes
-            npnode = count(isequal(node),hostnames)
+            npnode = count(isequal(node),hosts)
             @test np1[node] == npnode
         end
-        p1 = procs_node()
-        p2 = procs_node(workers(),hostnames,nodes)
+        p1 = @test_deprecated future_release_warn procs_node()
+        p2 = @test_deprecated future_release_warn procs_node(workers(), hosts, nodes)
         @test p1 == p2
         for node in nodes
-            pnode = workers()[findall(isequal(node),hostnames)]
+            pnode = workers()[findall(isequal(node),hosts)]
             @test p1[node] == pnode
         end
-        np4 = nprocs_node(p1)
+        np4 = @test_deprecated future_release_warn nprocs_node(p1)
         @test np1 == np4
     end
 end;


### PR DESCRIPTION
1. Functions specifically applied to `ProductSplit`: `extremadims`, `extrema_commonlastdim` and `procrange_recast` -- won't be exported anymore, but are available to be imported
2. `ntasks(x)` is deprecated in favor of `prod(length, x)`
3. `minimum(::ProductSplit, dim)`, `maximum(::ProductSplit, dim)` and `extrema(::ProductSplit, dim)` are deprecated in favor of the keyword-argument versions. Similarly `nelements(::ProductSplit, dim)` is deprecated in favor of `nelements(::ProductSplit; dim)`
4. `showprogress` is deprecated in `pmapreduce*`
5. Functions to query a cluster are are moved to a submodule `ClusterQueryUtils`. These won't be exported in the future.
6. `gethostnames` is deprecated and renamed to `hostnames`
