### PR TITLE
ProductSplit uses ProductSection

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,8 +284,9 @@ julia> xrange_long,yrange_long,zrange_long = 1:3000,1:3000,1:3000
 
 julia> params_long = (xrange_long,yrange_long,zrange_long);
 
-julia> ps_long = ProductSplit(params_long, 10, 4)
-ProductSplit{Tuple{Int64,Int64,Int64},3,UnitRange{Int64}}((1:3000, 1:3000, 1:3000), (0, 3000, 9000000), 10, 4, 8100000001, 10800000000)
+julia> ps = ProductSplit(params_long, 10, 3)
+2700000000-element ProductSplit((1:3000, 1:3000, 1:3000), 10, 3)
+[(1, 1, 601), ... , (3000, 3000, 900)]
 
 # Evaluate length using random ranges to avoid compiler optimizations
 julia> @btime length(p) setup = (n = rand(3000:4000); p = ProductSplit((1:n,1:n,1:n), 200, 2));
@@ -333,25 +334,24 @@ Another useful function is `whichproc` that returns the rank of the processor a 
 julia> whichproc(params_long, val, 10)
 4
 
-julia> @btime whichproc($params_long, $val, 10)
-  1.264 μs (14 allocations: 448 bytes)
-4
+julia> @btime whichproc($params_long, $val, 10);
+  353.706 ns (0 allocations: 0 bytes)
 ```
 
 ### Extrema
 
-We can compute the ranges of each variable on any processor in `O(1)` time. 
+We may compute the ranges of each variable on any processor in `O(1)` time. 
 
 ```julia
-julia> extrema(ps, dim=2) # extrema of the second parameter on this processor
+julia> extrema(ps, dim = 2) # extrema of the second parameter on this processor
 (3, 4)
 
-julia> Tuple(extrema(ps, dim=i) for i in 1:3)
+julia> Tuple(extrema(ps, dim = i) for i in 1:3)
 ((1, 3), (3, 4), (4, 4))
 
 # Minimum and maximum work similarly
 
-julia> (minimum(ps, dim=2), maximum(ps, dim=2))
+julia> (minimum(ps, dim = 2), maximum(ps, dim = 2))
 (3, 4)
 
 julia> @btime extrema($ps_long, dim=2)

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -1,17 +1,3 @@
-struct ProcessorNumberError <: Exception 
-	p :: Int
-	np :: Int
-end
-function Base.showerror(io::IO,err::ProcessorNumberError)
-	print(io,"processor id $(err.p) does not lie in the range $(1:err.np)")
-end
-
-struct DecreasingIteratorError <: Exception 
-end
-function Base.showerror(io::IO,err::DecreasingIteratorError)
-	print(io,"all the iterators need to be strictly increasing")
-end
-
 struct TaskNotPresentError{T,U} <: Exception
 	t :: T
 	task :: U

--- a/src/productsplit.jl
+++ b/src/productsplit.jl
@@ -38,6 +38,15 @@ struct ProductSection{T,N,Q} <: AbstractConstrainedProduct{T,N}
     end
 end
 
+function _cumprod(len::Tuple)
+    (0,_cumprod(first(len),Base.tail(len))...)
+end
+
+_cumprod(::Integer,::Tuple{}) = ()
+function _cumprod(n::Integer, tl::Tuple)
+    (n,_cumprod(n*first(tl),Base.tail(tl))...)
+end
+
 """
     ProductSection(iterators::Tuple{Vararg{AbstractRange}}, inds::AbstractUnitRange)
 
@@ -71,7 +80,7 @@ function ProductSection(iterators::Tuple{AbstractRange,Vararg{AbstractRange}},
         ArgumentError("the range of indices must start from a number ≥ 1"))
     lastind <= Nel || throw(
         ArgumentError("the maximum index must be less than or equal to the total number of elements = $Nel"))
-    togglelevels = (0, Base.front(accumulate(*, len))...)
+    togglelevels = _cumprod(len)
     ProductSection(iterators, togglelevels, firstind, lastind)
 end
 ProductSection(::Tuple{}, ::AbstractUnitRange) = throw(ArgumentError("Need at least one iterator"))
@@ -595,7 +604,7 @@ map(i -> extrema(ps, dim = i), 1:ndims(ps))
 
 but it is implemented more efficiently. 
 
-Returns a `Tuple` containing the `(min, max)` pairs along each 
+Returns a `Tuple` containing the `(min,max)` pairs along each 
 dimension, such that the `i`-th index of the result contains the `extrema` along the section of the `i`-th range
 contained locally.
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,7 +6,7 @@ Number of workers required to contain the outer product of the iterators.
 function nworkersactive(iterators::Tuple)
     min(nworkers(), prod(length, iterators))
 end
-nworkersactive(ps::ProductSplit) = nworkersactive(ps.iterators)
+nworkersactive(ps::AbstractConstrainedProduct) = nworkersactive(getiterators(ps))
 nworkersactive(args::AbstractRange...) = nworkersactive(args)
 
 """
@@ -17,5 +17,5 @@ If `prod(length, iterators) < nworkers()` then the first `prod(length, iterators
 workers are chosen.
 """
 workersactive(iterators::Tuple) = workers()[1:nworkersactive(iterators)]
-workersactive(ps::ProductSplit) = workersactive(ps.iterators)
+workersactive(ps::AbstractConstrainedProduct) = workersactive(getiterators(ps))
 workersactive(args::AbstractRange...) = workersactive(args)

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -10,7 +10,7 @@
     maybepvalput!, createbranchchannels, nworkersactive, workersactive,
     procs_node, leafrankfoldedtree,
     TopTreeNode, SubTreeNode, ProductSection, indexinproduct, dropleading,
-    nelements
+    nelements, getiterators, firstindexglobal, lastindexglobal
 end
 
 const future_release_warn = r"will not be exported in a future release"i
@@ -66,22 +66,15 @@ end
                     @test ndims(ps) == length(iters)
     		        @test collect(ps) == collect(split_product_across_processors_iterators(iters,np,p))
     		        @test (@test_deprecated ntasks(ps)) == ntasks_total
-    		        @test prod(length, ps.iterators) == ntasks_total
+    		        @test prod(length, getiterators(ps)) == ntasks_total
                     @test ParallelUtilities.workerrank(ps) == p
     		    end
 
-    		    @test_throws ParallelUtilities.ProcessorNumberError ProductSplit(iters,npmax,npmax+1)
+    		    @test_throws ArgumentError ProductSplit(iters, npmax, npmax+1)
     		end
 
     		@testset "0D" begin
     		    @test_throws ArgumentError ProductSplit((),2,1)
-    		end
-
-    		@testset "cumprod" begin
-    		    @test ParallelUtilities._cumprod(1,()) == ()
-    		    @test ParallelUtilities._cumprod(1,(2,)) == (1,)
-    		    @test ParallelUtilities._cumprod(1,(2,3)) == (1,2)
-    		    @test ParallelUtilities._cumprod(1,(2,3,4)) == (1,2,6)
     		end
 
         	@testset "1D" begin
@@ -119,22 +112,22 @@ end
         	    for iters in [(1:10,),(1:2,Base.OneTo(4),1:3:10)]
     	    	    ps = ProductSplit(iters,2,1)
     	    	    @test firstindex(ps) == 1
-    	    	    @test ps.firstind == 1
-    	    	    @test ps.lastind == div(prod(length, iters),2)
+    	    	    @test firstindexglobal(ps) == 1
+    	    	    @test lastindexglobal(ps) == div(prod(length, iters),2)
     	    	    @test lastindex(ps) == div(prod(length, iters),2)
     	    	    @test lastindex(ps) == length(ps)
     	    	    ps = ProductSplit(iters,2,2)
-    	    	    @test ps.firstind == div(prod(length, iters),2) + 1
+    	    	    @test firstindexglobal(ps) == div(prod(length, iters),2) + 1
     	    	    @test firstindex(ps) == 1
-    	    	    @test ps.lastind == prod(length, iters)
+    	    	    @test lastindexglobal(ps) == prod(length, iters)
     	    	    @test lastindex(ps) == length(ps)
 
     	    	    for np in prod(length, iters)+1:prod(length, iters)+10,
     	    	    	p in prod(length, iters)+1:np
 
     		    	    ps = ProductSplit(iters,np,p)
-    		    	    @test ps.firstind == prod(length, iters) + 1
-    		    	    @test ps.lastind == prod(length, iters)
+    		    	    @test firstindexglobal(ps) == prod(length, iters) + 1
+    		    	    @test lastindexglobal(ps) == prod(length, iters)
     		    	end
     		    end
         	end
@@ -146,14 +139,14 @@ end
                 @test ParallelUtilities.mwerepr(ps) == reprstr
 
                 summarystr = "$(length(ps))-element "*reprstr
-                @test ParallelUtilities.summary(ps) == summarystr
+                @test contains(ParallelUtilities.summary(ps), summarystr)
 
                 io = IOBuffer()
                 summary(io,ps)
-                @test String(take!(io)) == summarystr
+                @test contains(String(take!(io)), summarystr)
 
                 show(io, ps)
-                @test String(take!(io)) == reprstr
+                @test contains(String(take!(io)), summarystr)
             end
         end
 
@@ -417,7 +410,6 @@ end
             end
 
             @test_throws ArgumentError ProductSection((),2:3)
-            @test_throws ArgumentError ProductSection((1:3,),1:0)
         end
     end
     @testset "dropleading" begin
@@ -2626,14 +2618,6 @@ end;
     @testset "error" begin
         io = IOBuffer()
         
-        showerror(io,ParallelUtilities.ProcessorNumberError(5,2))
-        strexp = "processor id 5 does not lie in the range 1:2"
-        @test String(take!(io)) == strexp
-
-        showerror(io,ParallelUtilities.DecreasingIteratorError())
-        strexp = "all the iterators need to be strictly increasing"
-        @test String(take!(io)) == strexp
-
         showerror(io,ParallelUtilities.TaskNotPresentError((1:4,),(5,)))
         strexp = "could not find the task $((5,)) in the list $((1:4,))"
         @test String(take!(io)) == strexp


### PR DESCRIPTION
Also Improvement in `whichproc`

on master:

```julia
julia> xrange_long, yrange_long, zrange_long = 1:3000, 1:3000, 1:3000;

julia> params_long = (xrange_long, yrange_long, zrange_long);

julia> ps = ProductSplit(params_long, 10, 3);

julia> val = (10,2,901);

julia> @btime whichproc($params_long, $val, 10)
  1.224 μs (14 allocations: 448 bytes)
4
```

after this PR:

```julia
julia> @btime whichproc($params_long, $val, 10)
  357.481 ns (0 allocations: 0 bytes)
4
```