### PR TITLE
return nothing in whichproc_localindex instead of (nothing, nothing)

### DIFF
--- a/src/productsplit.jl
+++ b/src/productsplit.jl
@@ -906,7 +906,9 @@ julia> ParallelUtilities.ProductSplit(iters, np, 4) |> collect
 """
 function whichproc_localindex(iterators::Tuple{Vararg{AbstractRange}}, val::Tuple, np::Integer)
     procid = whichproc(iterators, val, np)
+    procid === nothing && return nothing
     index = localindex(ProductSplit(iterators, np, procid), val)
+    index === nothing && return nothing
     return procid, index
 end
 

--- a/test/productsplit.jl
+++ b/test/productsplit.jl
@@ -337,6 +337,7 @@ end
                     end
                 end
             end
+            @test whichproc_localindex((1:1,1:1), (1,2), 1) === nothing
         end
 
         @testset "getindex" begin


### PR DESCRIPTION
This helps in union splitting